### PR TITLE
Add KB builder utility and secure resin list endpoint

### DIFF
--- a/kb_build.py
+++ b/kb_build.py
@@ -1,0 +1,161 @@
+"""Ferramenta para gerar o kb_index.json em partes controladas.
+
+Objetivos principais:
+- Evitar estouros de tempo/memória permitindo limitar quantos arquivos são processados.
+- Verificar se a variável OPENAI_API_KEY está presente antes de chamar a API.
+- Possibilitar dry-run (sem chamadas à API) para validar o pipeline rapidamente.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:
+    from openai import OpenAI  # type: ignore
+except Exception:  # pragma: no cover - import guard
+    OpenAI = None  # type: ignore
+
+MODEL_NAME = "text-embedding-3-large"
+DEFAULT_INPUT_DIR = Path("rag-knowledge")
+DEFAULT_OUTPUT = Path("kb_index.json")
+
+
+def load_existing_index(output_path: Path) -> Dict[str, dict]:
+    if not output_path.exists():
+        return {}
+
+    try:
+        raw = json.loads(output_path.read_text())
+        docs = raw.get("documents", raw)
+        return {doc.get("id") or doc.get("path"): doc for doc in docs if isinstance(doc, dict)}
+    except json.JSONDecodeError:
+        print(f"⚠️  Arquivo {output_path} está corrompido ou vazio. Iniciando novo índice.")
+        return {}
+
+
+def save_index(output_path: Path, documents: List[dict]) -> None:
+    payload = {
+        "model": MODEL_NAME,
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "documents": documents,
+    }
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def get_files(input_dir: Path, start: int, limit: Optional[int]) -> List[Path]:
+    files = sorted(input_dir.glob("*.txt"))
+    sliced = files[start:]
+    if limit is not None:
+        sliced = sliced[:limit]
+    return sliced
+
+
+def build_index(
+    input_dir: Path,
+    output_path: Path,
+    start: int,
+    limit: Optional[int],
+    batch_size: int,
+    max_chars: int,
+    dry_run: bool,
+) -> None:
+    if not input_dir.exists():
+        raise SystemExit(f"Diretório de conhecimento não encontrado: {input_dir}")
+
+    existing = load_existing_index(output_path)
+    documents: List[dict] = list(existing.values())
+
+    if not dry_run:
+        if OpenAI is None:
+            raise SystemExit("Biblioteca `openai` não instalada. Execute `pip install openai`.\n" "Use --dry-run para testar sem API.")
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise SystemExit("OPENAI_API_KEY não configurada no ambiente.")
+        client = OpenAI(api_key=api_key)
+    else:
+        client = None
+
+    files = get_files(input_dir, start, limit)
+    if not files:
+        print("Nenhum arquivo .txt encontrado para processar.")
+        return
+
+    processed = 0
+    new_docs = 0
+
+    for idx, file_path in enumerate(files, start=1):
+        file_id = file_path.name
+        if file_id in existing:
+            print(f"↪️  Pulando {file_id} (já presente no índice)")
+            continue
+
+        text = file_path.read_text(encoding="utf-8", errors="ignore").strip()
+        title, _, body = text.partition("\n")
+        embed_input = text[:max_chars]
+
+        embedding: List[float]
+        if dry_run:
+            embedding = []
+        else:
+            response = client.embeddings.create(model=MODEL_NAME, input=embed_input)
+            embedding = response.data[0].embedding
+
+        documents.append(
+            {
+                "id": file_id,
+                "source": str(file_path),
+                "title": title or file_path.stem,
+                "content": body.strip() or text,
+                "embedding_model": MODEL_NAME,
+                "embedding": embedding,
+            }
+        )
+
+        new_docs += 1
+        processed += 1
+
+        if new_docs % batch_size == 0:
+            save_index(output_path, documents)
+            print(f"💾 Progresso salvo após {new_docs} novos documentos (arquivo: {file_id})")
+
+        print(f"✅ Processado {file_id} ({idx}/{len(files)})")
+
+    if new_docs:
+        save_index(output_path, documents)
+        print(f"🎉 Index final salvo com {len(documents)} documentos no total.")
+    else:
+        print("Nenhum novo documento adicionado. Índice permanece inalterado.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Gerar kb_index.json em lotes menores")
+    parser.add_argument("--input-dir", type=Path, default=DEFAULT_INPUT_DIR, help="Pasta com arquivos .txt da base de conhecimento")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="Arquivo de saída (kb_index.json)")
+    parser.add_argument("--start", type=int, default=0, help="Arquivo inicial (offset) para processar")
+    parser.add_argument("--limit", type=int, help="Quantidade máxima de arquivos a processar")
+    parser.add_argument("--batch-size", type=int, default=5, help="Grava a cada N novos documentos")
+    parser.add_argument("--max-chars", type=int, default=8000, help="Trunca o texto enviado para a API")
+    parser.add_argument("--dry-run", action="store_true", help="Não chama a API; útil para testes rápidos")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    try:
+        build_index(
+            input_dir=args.input_dir,
+            output_path=args.output,
+            start=args.start,
+            limit=args.limit,
+            batch_size=args.batch_size,
+            max_chars=args.max_chars,
+            dry_run=args.dry_run,
+        )
+    except SystemExit as exc:  # Propagar mensagens amigáveis
+        print(str(exc))
+        sys.exit(1)

--- a/kb_index.json
+++ b/kb_index.json
@@ -1,0 +1,22 @@
+{
+  "model": "text-embedding-3-large",
+  "generated_at": "2025-12-18T16:25:04.413543Z",
+  "documents": [
+    {
+      "id": "chunk_199.txt",
+      "source": "rag-knowledge/chunk_199.txt",
+      "title": "MELHOR PINTOR REALISTA DO BRASIL ARTUR MONTEIRO , CAROL OTTOLINI , PEDRO CALEIRO , BEATRIZ PESSOA , AMANDAWAYNE.ART , POLYPANT STUDIOS, PABLO TELLES , ANGELMAKER3D,",
+      "content": "ARTISTA COMPLETO DO BRASIL RENATOGUEDESART \nMELHOR MODELADOR DO BRASIL THIAGO SUBLIMESKINS , CARDOSO3D, CP STUDIOS CARLOS , \nMELHOR designer gráfico DO BRASIL  RODRIGO SICHEROLI",
+      "embedding_model": "text-embedding-3-large",
+      "embedding": []
+    },
+    {
+      "id": "chunk_200.txt",
+      "source": "rag-knowledge/chunk_200.txt",
+      "title": "=== 50 ERROS SLA/DLP + SOLUÇÃO RÁPIDA + MELHOR RESINA QUANTON3D ===",
+      "content": "1. Não gruda na base → 40–60s base, limpar FEP, Iron 7030 ou Pyroblast+\n2. Desprende no meio → Re-nivelar placa, lift speed 60–90 mm/min\n3. Peça quebra fácil → Baixar exposição 0,5s, usar Spin+, FlexForm ou VulcanCast\n4. Bolhas na peça → Mexer 3 min + descansar 10 min, Alchemist\n5. Elephant foot → Z lift base 10 mm, menos tempo base\n6. Buracos nas paredes → +0,5s exposição, Alchemist ou Spark\n7. Suporte cai → Suporte médio/pesado, tip 0,5 mm\n8. Resina pegajosa → Ambiente frio ou LED fraco → aquecer ou trocar LED\n9. FEP embaçado → Trocar FEP, limpar só com álcool 99%\n10. Gruda no FEP → +10s nas camadas base ou lixar leve FEP\n11. Camadas visíveis → AA nível 8 + Grey offset 50%\n12. Quebra ao tirar suporte → FlexForm ou -0,5s exposição\n13. Sucção forte (pop) → Hollow + 4 furos 3–4 mm\n14. Resina vaza da cuba → Apertar parafusos da cuba\n15. Para no meio → Trocar pendrive (FAT32)\n16. Manchas brancas → Resina contaminada → trocar\n17. Detalhe some → Alchemist 1,8–2,2s em 0,03 mm\n18. Encolhimento pós-cura → Resina velha ou exposição alta\n19. Bleeding → -0,3s ou Bloom 0\n20. Suction cups → Hollow + furos + lift lento\n21. Ghosting → Lift speed ≤60 mm/min\n22. Textura arenosa → +0,5s exposição\n23. FEP rasga rápido → Velocidade descida lenta ou nFEP\n24. Resina cura sozinha → Tampa aberta → guardar no escuro\n25. Falha só no canto → Re-nivelar ou tirar bolha da cuba\n26. Peça muito translúcida → Exposição alta → baixar\n27. Amarela na cura → Máximo 3–5 min na estação UV\n28. Suporte não gruda na peça → Base do suporte 1,4×\n29. Marca de suporte funda → Depth 0,5 mm\n30. Resina muito grossa no inverno → Aquecer garrafa 40°C\n31. Rachadura em peças grossas → Hollow + wall 2–3 mm\n32. Falha em peças grandes → Mais tempo base + raft\n33. Peça gruda demais na placa → Espátula flexível + calor leve\n34. Cheiro forte → Máscara + exaustor\n35. Tela LCD manchada → Limpar com álcool + trocar polarizador\n36. Overexposure spots → Calibrar tela ou -0,3s\n37. Light bleed → Dimming on (Lychee)\n38. Peça com veios → Temperatura <20°C → aquecer sala\n39. Camada 0,02 falha → Só Alchemist ou Spark\n40. FEP solta bolha → Apertar cuba uniformemente\n41. Impressão falha após 50% → Cuba com resina pouca\n42. Suporte muito fraco em miniatura → 100% densidade\n43. Peça opaca demais → Exposição baixa → +0,3s\n44. Resina endurece no bico (DLP) → Limpar bico a cada 2h\n45. Fantasmas em texto pequeno → Anti-aliasing 16\n46. Base muito grossa → Diminuir número de camadas base\n47. Peça solta da raft → Mais tempo base ou raft maior\n48. Bolhas só no topo → Resina do fundo do frasco → filtrar\n49. Impressão lenta demais → Lift speed 120–150 mm/min (só se não der sucção)\n50. Cliente reclama de cheiro → Recomendar Spin+ ou Alchemist (menos odor)",
+      "embedding_model": "text-embedding-3-large",
+      "embedding": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add kb_build.py tool to generate kb_index.json in controllable batches with API key validation and dry-run support
- initialize OPENAI_API_KEY warning and centralize admin authorization helper for routes
- protect resin list endpoint with the admin token and persist current partial kb_index.json output

## Testing
- python kb_build.py --dry-run --limit 2


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944295ca10c8333aa842530d8e127e8)