### PR TITLE
Add admin endpoint for batch knowledge import

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ import fs from 'fs';
 import path from 'path';
 // import rateLimit from "express-rate-limit"; // REMOVIDO - causando erro ERR_ERL_UNEXPECTED_X_FORWARDED_FOR
 import { initializeRAG, searchKnowledge, formatContext, addDocument, listDocuments, deleteDocument, updateDocument, addVisualKnowledge, searchVisualKnowledge, formatVisualResponse, listVisualKnowledge, deleteVisualKnowledge, generateEmbedding } from './rag-search.js';
-import { connectToMongo, getMessagesCollection, getGalleryCollection, getVisualKnowledgeCollection, getSuggestionsCollection, getPartnersCollection } from './db.js';
+import { connectToMongo, getMessagesCollection, getGalleryCollection, getVisualKnowledgeCollection, getSuggestionsCollection, getPartnersCollection, getDocumentsCollection } from './db.js';
 import { v2 as cloudinary } from 'cloudinary';
 import {
   analyzeQuestionType,
@@ -29,6 +29,7 @@ dotenv.config();
 
 const ADMIN_SECRET = process.env.ADMIN_SECRET || 'quanton3d_admin_secret';
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const RAG_EMBEDDING_MODEL = 'text-embedding-3-large';
 
 if (!OPENAI_API_KEY) {
   console.warn('⚠️  OPENAI_API_KEY não configurada - chamadas de IA irão falhar até definir a variável.');
@@ -78,6 +79,16 @@ const openai = new OpenAI({
 });
 
 const isAdminAuthorized = (token) => token === ADMIN_SECRET || token === 'quanton3d_admin_secret';
+
+const extractAdminToken = (req) => {
+  const authHeader = req.headers.authorization || '';
+  const bearerToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  const headerToken = req.headers['x-admin-secret'] || req.headers['x-admin-token'];
+  const queryToken = req.query?.auth;
+  const bodyToken = req.body && typeof req.body === 'object' && !Array.isArray(req.body) ? req.body.auth : null;
+
+  return headerToken || bearerToken || queryToken || bodyToken;
+};
 
 // Histórico de conversas por sessão
 const conversationHistory = new Map();
@@ -1239,6 +1250,88 @@ app.get("/metrics/client-history", async (req, res) => {
 
 // Rota para adicionar conhecimento manualmente ao RAG
 // CORRIGIDO: Agora usa addDocument() que salva no MongoDB com embedding
+app.post("/admin/knowledge/import", async (req, res) => {
+  const adminToken = extractAdminToken(req);
+
+  if (!isAdminAuthorized(adminToken)) {
+    return res.status(401).json({ success: false, error: 'Não autorizado' });
+  }
+
+  const items = Array.isArray(req.body) ? req.body : req.body?.items;
+
+  if (!Array.isArray(items) || items.length === 0) {
+    console.log('[IMPORT-KNOWLEDGE] Payload vazio ou inválido');
+    return res.status(400).json({ success: false, error: 'Lista de itens para importação é obrigatória' });
+  }
+
+  const validationErrors = [];
+
+  items.forEach((item, index) => {
+    const title = item?.title;
+    const content = item?.content;
+    const tags = item?.tags;
+
+    if (!title || typeof title !== 'string' || !title.trim()) {
+      validationErrors.push({ index, field: 'title', message: 'Título é obrigatório' });
+    }
+
+    if (!content || typeof content !== 'string' || !content.trim()) {
+      validationErrors.push({ index, field: 'content', message: 'Conteúdo é obrigatório' });
+    }
+
+    if (tags && !Array.isArray(tags)) {
+      validationErrors.push({ index, field: 'tags', message: 'Tags deve ser uma lista de strings' });
+    }
+  });
+
+  if (validationErrors.length > 0) {
+    console.log(`[IMPORT-KNOWLEDGE] Falha de validação em ${validationErrors.length} itens`);
+    return res.status(400).json({ success: false, error: 'Validação falhou', details: validationErrors });
+  }
+
+  try {
+    console.log(`[IMPORT-KNOWLEDGE] Iniciando importação de ${items.length} documentos`);
+    const collection = getDocumentsCollection();
+    const documentsToInsert = [];
+
+    for (let index = 0; index < items.length; index++) {
+      const item = items[index];
+      const title = item.title.trim();
+      const content = item.content.trim();
+      const source = typeof item.source === 'string' && item.source.trim() ? item.source.trim() : 'admin_import';
+      const tags = (Array.isArray(item.tags) ? item.tags : [])
+        .map(tag => (typeof tag === 'string' ? tag.trim() : ''))
+        .filter(Boolean);
+
+      console.log(`[IMPORT-KNOWLEDGE] (${index + 1}/${items.length}) Gerando embedding para "${title}"`);
+      const embedding = await generateEmbedding(content);
+
+      documentsToInsert.push({
+        title,
+        content,
+        source,
+        tags,
+        embedding,
+        embeddingModel: RAG_EMBEDDING_MODEL,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      });
+    }
+
+    const insertResult = await collection.insertMany(documentsToInsert);
+    console.log(`[IMPORT-KNOWLEDGE] Importação concluída com ${insertResult.insertedCount} documentos`);
+
+    return res.json({
+      success: true,
+      inserted: insertResult.insertedCount,
+      documentIds: Object.values(insertResult.insertedIds).map(id => id.toString())
+    });
+  } catch (err) {
+    console.error(`[IMPORT-KNOWLEDGE] Erro ao importar conhecimento: ${err.message}`);
+    return res.status(500).json({ success: false, error: 'Erro ao importar conhecimento', details: err.message });
+  }
+});
+
 app.post("/add-knowledge", async (req, res) => {
   try {
     const { auth, title, content } = req.body;


### PR DESCRIPTION
## Summary
- add helper for extracting admin tokens and reuse quanton3d admin secret validation
- implement /admin/knowledge/import route to validate and import batches with embeddings and tags
- insert imported documents into the MongoDB RAG collection with consistent metadata

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69442dd86e6c8333848db8b4e19ba25b)