### PR TITLE
Raise RAG threshold and clean knowledge base before imports

### DIFF
--- a/rag-knowledge/rag-helper.js
+++ b/rag-knowledge/rag-helper.js
@@ -17,9 +17,8 @@ const EMBEDDING_DIMENSIONS = 3072; // Dimensao do text-embedding-3-large
 
 // Limiar minimo de relevancia para considerar um documento util
 // Documentos com similaridade abaixo deste valor serao ignorados
-// NOTA: Reduzido de 0.7 para 0.5, e depois para 0.3 para melhorar recall
-// text-embedding-3-large pode ter scores mais baixos mesmo para documentos relevantes
-const MIN_RELEVANCE_THRESHOLD = 0.3;
+// NOTA: Ajustado para 0.8 (80%) para priorizar somente documentos altamente relevantes
+const MIN_RELEVANCE_THRESHOLD = 0.8;
 
 let lastInitialization = null;
 let documentsCount = 0;

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ import multer from "multer";
 import fs from 'fs';
 import path from 'path';
 // import rateLimit from "express-rate-limit"; // REMOVIDO - causando erro ERR_ERL_UNEXPECTED_X_FORWARDED_FOR
-import { initializeRAG, searchKnowledge, formatContext, addDocument, listDocuments, deleteDocument, updateDocument, addVisualKnowledge, searchVisualKnowledge, formatVisualResponse, listVisualKnowledge, deleteVisualKnowledge, generateEmbedding } from './rag-search.js';
+import { initializeRAG, searchKnowledge, formatContext, addDocument, listDocuments, deleteDocument, updateDocument, addVisualKnowledge, searchVisualKnowledge, formatVisualResponse, listVisualKnowledge, deleteVisualKnowledge, generateEmbedding, clearKnowledgeCollection } from './rag-search.js';
 import { connectToMongo, getMessagesCollection, getGalleryCollection, getVisualKnowledgeCollection, getSuggestionsCollection, getPartnersCollection, getDocumentsCollection } from './db.js';
 import { v2 as cloudinary } from 'cloudinary';
 import {
@@ -1312,6 +1312,9 @@ app.post("/admin/knowledge/import", async (req, res) => {
     }
 
     console.log(`[IMPORT-KNOWLEDGE] Recebidos ${docsPayload.length} documentos para importação`);
+
+    const cleanupResult = await clearKnowledgeCollection();
+    console.log(`[IMPORT-KNOWLEDGE] Coleção limpa antes do import: ${cleanupResult.deleted} registros removidos.`);
 
     const imported = [];
     const errors = [];


### PR DESCRIPTION
## Summary
- raise the RAG minimum relevance threshold to 80% and boost hardware:LCD_check documents when LCD fault keywords appear
- add a helper to clear the MongoDB knowledge collection and invoke it before admin batch imports to avoid duplicates
- keep the legacy RAG helper threshold aligned with the new relevance target

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944408faa58833384d1e9823e293f46)