### PR TITLE
Handle knowledge import fallback to local kb_index

### DIFF
--- a/server.js
+++ b/server.js
@@ -1292,6 +1292,16 @@ app.post("/admin/knowledge/import", async (req, res) => {
       return res.status(401).json({ success: false, error: 'Não autorizado' });
     }
 
+    const bodyIsEmpty = () => {
+      if (!req.body) return true;
+      if (typeof req.body === 'string') return req.body.trim().length === 0;
+      if (Buffer.isBuffer(req.body)) return req.body.length === 0;
+      if (typeof req.body === 'object') {
+        return Object.keys(req.body).length === 0;
+      }
+      return false;
+    };
+
     let docsPayload = Array.isArray(req.body?.documents)
       ? req.body.documents
       : Array.isArray(req.body)
@@ -1313,7 +1323,7 @@ app.post("/admin/knowledge/import", async (req, res) => {
       return cleanupResult;
     };
 
-    if (!Array.isArray(docsPayload) || docsPayload.length === 0) {
+    if (bodyIsEmpty() || !Array.isArray(docsPayload) || docsPayload.length === 0) {
       const kbPath = path.join(process.cwd(), 'kb_index.json');
 
       try {


### PR DESCRIPTION
## Summary
- fall back to loading kb_index.json when /admin/knowledge/import receives an empty body
- guard against empty requests by detecting empty bodies and triggering the import fallback while clearing the collection first

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694450ff038883338d36591095678fcf)