### PR TITLE
Improve kb_index import parsing

### DIFF
--- a/scripts/import-kb-with-tags.js
+++ b/scripts/import-kb-with-tags.js
@@ -43,11 +43,19 @@ function loadKbIndex() {
     throw new Error(`Arquivo kb_index.json não encontrado em ${KB_INDEX_PATH}`);
   }
   const raw = fs.readFileSync(KB_INDEX_PATH, 'utf-8');
-  const parsed = JSON.parse(raw);
-  const documents = Array.isArray(parsed?.documents) ? parsed.documents : parsed;
+  const parsed = JSON.parse(raw.replace(/\s+$/u, ''));
+  const documents = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.documents)
+      ? parsed.documents
+      : Array.isArray(parsed?.data)
+        ? parsed.data
+        : Object.values(parsed || {}).find(Array.isArray) || null;
+
   if (!Array.isArray(documents)) {
-    throw new Error('Formato do kb_index.json inválido: campo "documents" ausente.');
+    throw new Error('Formato do kb_index.json inválido: arquivo não contém um array de documentos.');
   }
+
   return documents;
 }
 


### PR DESCRIPTION
## Summary
- allow kb import endpoint to parse document arrays whether stored at root or nested keys and trim trailing whitespace
- update import helper script to tolerate nested data keys and clarify error handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694452ba8ab88333ab9ed7dd1f2c35fc)