### PR TITLE
Restore timestamps during KB import upserts

### DIFF
--- a/scripts/import-kb-with-tags.js
+++ b/scripts/import-kb-with-tags.js
@@ -125,6 +125,8 @@ async function importDocuments({ dryRun, limit }) {
       filter: { legacyId: doc.legacyId },
       update: {
         $set: doc,
+        $setOnInsert: { createdAt: new Date() },
+        $currentDate: { updatedAt: true },
       },
       upsert: true,
     },


### PR DESCRIPTION
## Summary
- ensure bulk upserts set createdAt for inserts and refresh updatedAt on every operation
- keep sanitized knowledge base payloads while letting MongoDB manage timestamps

## Testing
- node scripts/import-kb-with-tags.js --dry-run --limit=1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694461eaa3888333a4c288c9a4abe6f0)