### PR TITLE
Sanitize timestamps before upserting documents

### DIFF
--- a/rag-search.js
+++ b/rag-search.js
@@ -316,16 +316,21 @@ export async function addDocument(title, content, source = 'suggestion', tags = 
       ...(options.legacyId ? { legacyId: options.legacyId } : {})
     };
 
+    const sanitizedDocument = { ...baseDocument };
+    delete sanitizedDocument.createdAt;
+    delete sanitizedDocument.updatedAt;
+
     let documentId = null;
     let inserted = false;
 
     if (options.upsert && options.legacyId) {
       const existing = await collection.findOne({ legacyId: options.legacyId }, { projection: { _id: 1, createdAt: 1 } });
+      const createdAtValue = existing?.createdAt || baseDocument.createdAt;
       const result = await collection.updateOne(
         { legacyId: options.legacyId },
         {
-          $set: { ...baseDocument, createdAt: existing?.createdAt || baseDocument.createdAt },
-          $setOnInsert: { createdAt: existing?.createdAt || baseDocument.createdAt }
+          $set: { ...sanitizedDocument, updatedAt: baseDocument.updatedAt },
+          $setOnInsert: { createdAt: createdAtValue }
         },
         { upsert: true }
       );


### PR DESCRIPTION
## Summary
- sanitize imported documents by removing createdAt and updatedAt before upserts
- ensure createdAt is only set via $setOnInsert while updating updatedAt explicitly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694486e4bae4833390f5149955ffa4be)