### PR TITLE
Expose full resin and printer lists in params endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -3474,14 +3474,8 @@ async function searchKnowledgeWithPrintParams(query, entities, questionType, top
   return results;
 }
 
-// GET /params/resins - Listar todas as resinas (protegido por token admin)
+// GET /params/resins - Listar todas as resinas
 app.get("/params/resins", (req, res) => {
-  const auth = getAdminAuth(req);
-
-  if (!isAdminAuthorized(auth)) {
-    return res.status(401).json({ success: false, error: 'Não autorizado' });
-  }
-
   res.json({
     success: true,
     resins: printParametersDB.resins,
@@ -3492,6 +3486,7 @@ app.get("/params/resins", (req, res) => {
 // GET /params/printers - Listar todas as impressoras
 app.get("/params/printers", (req, res) => {
   const { resinId } = req.query;
+  const allPrinters = printParametersDB.printers;
   
   if (resinId) {
     // Filtrar impressoras que têm perfil para esta resina
@@ -3503,14 +3498,16 @@ app.get("/params/printers", (req, res) => {
     const filteredPrinters = printParametersDB.printers.filter(p => printerIds.has(p.id));
     res.json({
       success: true,
-      printers: filteredPrinters,
-      count: filteredPrinters.length
+      printers: allPrinters,
+      count: allPrinters.length,
+      matchingPrinters: filteredPrinters,
+      matchingCount: filteredPrinters.length
     });
   } else {
     res.json({
       success: true,
-      printers: printParametersDB.printers,
-      count: printParametersDB.printers.length
+      printers: allPrinters,
+      count: allPrinters.length
     });
   }
 });


### PR DESCRIPTION
### Motivation
- The admin and main panels need to display the complete catalog of resins and printers so users see all registered items. 
- Previously `/params/resins` required admin auth which prevented the UI from loading the resin list.
- `/params/printers` returned only the filtered subset when a `resinId` was supplied which made it hard for the frontend to show the full catalog and highlight matches.
- Make the params endpoints easier to consume by the public/admin panels without extra auth for read-only lists.

### Description
- Removed the admin authorization check from `GET /params/resins` so it now returns the full `printParametersDB.resins` list unconditionally.
- Updated `GET /params/printers` to always return the full printer catalog as `printers` and `count`, and when a `resinId` is provided the response also includes `matchingPrinters` and `matchingCount` (the previously returned filtered subset).
- Introduced a local `allPrinters` variable and adjusted JSON response shape to include both full and matching subsets for easier UI consumption.
- No changes were made to the underlying data files (`data/print-parameters-db.json` / `print-parameters-rag.json`) or profile filtering logic.

### Testing
- Inspected `data/print-parameters-db.json` with `node -e` to print `stats` and verified totals (`totalProfiles`, `totalResins`, `totalPrinters`); command succeeded.
- Enumerated distinct resins and printers from `data/print-parameters-rag.json` with `node -e` to confirm lists are present and correct; command succeeded.
- Ran a sanity check script with `node -e` that verifies no profile references a missing `resinId` or `printerId` and confirmed there are no missing IDs; check succeeded.
- No automated unit/integration test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69482c53244c8333a618ad478926b08e)