### PR TITLE
Adjust quick-actions layout: push down, force horizontal rows, tighten gaps

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -245,10 +245,11 @@ button.ghost {
 
 .quick-actions {
   display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 8px;
   justify-content: center;
-  margin-top: 120px;
+  margin-top: 240px;
   padding: 24px 0 40px;
 }
 


### PR DESCRIPTION
### Motivation
- Free up the central top area for the bot response by pushing the quick-action block closer to the page footer.  
- Replace any stacked/pyramidal presentation with a strict horizontal row-based layout so actions appear side-by-side in lines.  
- Add modest spacing between action buttons so they don't appear glued while keeping the block compact.  
- Ensure lower content follows this movement and stays visible below the action buttons.

### Description
- Updated `public/styles.css` to modify the `.quick-actions` block by adding `flex-direction: row` to enforce horizontal layout.  
- Reduced the inter-button `gap` from `16px` to `8px` to tighten spacing.  
- Doubled the vertical offset by increasing `margin-top` on `.quick-actions` from `120px` to `240px` to push the block further down.  
- Kept `flex-wrap: wrap` so buttons will wrap into subsequent rows when needed and left `.chip` styling intact.

### Testing
- Launched a local static server with `python -m http.server --directory public` and loaded `index.html` to validate visual changes.  
- Executed a Playwright script to open `http://127.0.0.1:8000/index.html` at `1280x720` and capture `artifacts/quick-actions-layout.png`.  
- Both the local server and the Playwright screenshot run completed successfully.  
- No automated unit tests were run because this is a static CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694881dc297083339ecd381a29189207)