### PR TITLE
Left-align and lower quick-action buttons

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -248,8 +248,9 @@ button.ghost {
   flex-direction: row;
   flex-wrap: wrap;
   gap: 8px;
-  justify-content: center;
-  margin-top: 240px;
+  justify-content: flex-start;
+  align-items: flex-start;
+  margin-top: 250px;
   padding: 24px 0 40px;
 }
 


### PR DESCRIPTION
### Motivation

- Break the centered "pyramid" layout for the quick action buttons so they appear as horizontal rows.
- Move the quick actions block lower on the page to create a large empty area between the robot and the buttons.
- Ensure buttons wrap into additional rows while staying horizontally oriented.

### Description

- Modified `public/styles.css` to update the `.quick-actions` rule to `justify-content: flex-start;` and added `align-items: flex-start;`.
- Increased the top spacing by changing `margin-top` from `240px` to `250px` in `public/styles.css`.
- Retained `display: flex;`, `flex-direction: row;`, and `flex-wrap: wrap;` so buttons align in horizontal rows and wrap as needed.

### Testing

- Launched a local server using `python -m http.server` and it started successfully.
- Ran a Playwright script to load `index.html` and capture a layout screenshot, which completed and produced the artifact `artifacts/quick-actions-layout.png`.
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694891e6fe208333b5146f673fb27677)