### PR TITLE
Center quick-actions and push to footer (styles.css)

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -247,10 +247,10 @@ button.ghost {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  gap: 8px;
-  justify-content: flex-start;
-  align-items: flex-start;
-  margin-top: 250px;
+  gap: 10px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 400px;
   padding: 24px 0 40px;
 }
 


### PR DESCRIPTION
### Motivation

- Ensure the action buttons block is moved to the footer area so the central response area stays visually clear for the "BOT RESPONDE" content.
- Replace the pyramid-like arrangement with a consistent single-line, wrapped row layout for the main action buttons and gallery items.

### Description

- Updated `public/styles.css` and modified the `.quick-actions` rule to use `gap: 10px`, `justify-content: center`, `align-items: center`, and `margin-top: 400px` to center and push the block downward.
- Retains `display: flex; flex-direction: row; flex-wrap: wrap;` to keep actions in a wrapped row layout.
- This change causes the `Galeria de Fotos`/chip buttons inside `.quick-actions` to follow the new spacing and vertical offset and clears the central area where the bot response appears.

### Testing

- Served the `public/` folder with `python -m http.server` and captured a full-page screenshot with Playwright, which succeeded.
- Running `npm start` failed due to missing environment variables (`MONGODB_URI` and `OPENAI_API_KEY`), which prevented the Node server from starting.
- The change is a static CSS update and does not require additional unit tests; visual verification via the generated screenshot confirms the layout adjustment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948952c39708333b0f4f33b52a20559)