### PR TITLE
Integrar segurança JWT do admin e migrar parâmetros de impressão para MongoDB

### DIFF
--- a/admin/security.js
+++ b/admin/security.js
@@ -3,9 +3,9 @@
 // Drop-in de segurança (login JWT, rotas admin protegidas e SSE).
 // Por quê: tirar senha do HTML, limitar brute-force e proteger painel.
 // =====================================================================
-const jwt = require("jsonwebtoken");
-const rateLimit = require("express-rate-limit");
-const cors = require("cors");
+import jwt from "jsonwebtoken";
+import rateLimit from "express-rate-limit";
+import cors from "cors";
 
 function allowListFromEnv(v){ return (v||"").split(",").map(s=>s.trim()).filter(Boolean); }
 function issueToken(secret){ return jwt.sign({ role: "admin" }, secret, { expiresIn: "30m" }); }
@@ -82,7 +82,7 @@ function attachAdminSecurity(app){
   console.log("[admin] Rotas: /admin/login, /admin/feedback, /admin/stream");
 }
 
-module.exports = { attachAdminSecurity };
+export { attachAdminSecurity };
 
 
 // =====================================================================

--- a/db.js
+++ b/db.js
@@ -42,6 +42,10 @@ export async function connectToMongo() {
       await db.createCollection('messages');
       console.log('[MongoDB] Colecao "messages" criada');
     }
+    if (!collectionNames.includes('print_parameters')) {
+      await db.createCollection('print_parameters');
+      console.log('[MongoDB] Colecao "print_parameters" criada');
+    }
     
     return db;
   } catch (err) {
@@ -94,6 +98,11 @@ export function getPartnersCollection() {
   return getDb().collection('partners');
 }
 
+// Obter colecao de parametros de impressao
+export function getPrintParametersCollection() {
+  return getDb().collection('print_parameters');
+}
+
 // Fechar conexao (para cleanup)
 export async function closeMongo() {
   if (client) {
@@ -118,6 +127,7 @@ export default {
   getVisualKnowledgeCollection,
   getSuggestionsCollection,
   getPartnersCollection,
+  getPrintParametersCollection,
   closeMongo,
   isConnected
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "express-rate-limit": "^8.2.1",
+        "jsonwebtoken": "^9.0.3",
         "mongodb": "^7.0.0",
         "multer": "^1.4.5-lts.1",
         "openai": "^4.58.1"
@@ -418,6 +419,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -811,6 +818,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1285,10 +1301,101 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/long": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-rate-limit": "^8.2.1",
+    "jsonwebtoken": "^9.0.3",
     "mongodb": "^7.0.0",
     "multer": "^1.4.5-lts.1",
     "openai": "^4.58.1"

--- a/public/params-panel.html
+++ b/public/params-panel.html
@@ -386,7 +386,7 @@
         printers: [],
         profiles: [],
         page: 1,
-        limit: 25,
+        limit: null,
         total: 0
       };
 
@@ -457,6 +457,10 @@
       };
 
       const renderPagination = () => {
+        if (!state.limit) {
+          pagination.innerHTML = "";
+          return;
+        }
         const totalPages = Math.max(Math.ceil(state.total / state.limit), 1);
         pagination.innerHTML = `
           <span>Página ${state.page} de ${totalPages}</span>
@@ -548,8 +552,10 @@
         if (resinSelect.value) params.append("resinId", resinSelect.value);
         if (printerSelect.value) params.append("printerId", printerSelect.value);
         if (statusSelect.value) params.append("status", statusSelect.value);
-        params.append("page", state.page);
-        params.append("limit", state.limit);
+        if (state.limit) {
+          params.append("page", state.page);
+          params.append("limit", state.limit);
+        }
 
         const response = await fetch(`${API_BASE}/params/profiles?${params.toString()}`);
         const data = await response.json();


### PR DESCRIPTION
### Motivation
- Substituir o mecanismo frágil de token estático por autenticação JWT para proteger rotas administrativas.  
- Centralizar persistência em MongoDB e remover dependência de arquivos locais para o banco de parâmetros de impressão.  
- Expor `print_parameters` como coleção do Mongo para consultas/atualizações consistentes.  
- Permitir ao painel admin visualizar todos os perfis removendo a paginação forçada de 25 itens.

### Description
- Integrei o middleware de segurança do `admin/security.js` chamando `attachAdminSecurity(app)` no `server.js` e converti o arquivo `admin/security.js` para ESM exportando `attachAdminSecurity`.  
- Troquei as verificações antigas (`isAdminAuthorized` / `extractAdminToken` por token estático) por validação real de JWT (Bearer token) via `jsonwebtoken` e adicionei a helper `ensureAdminAuthorized(req, res)` usada nas rotas administrativas.  
- Adicionei a coleção `print_parameters` em `db.js` e exportei `getPrintParametersCollection()`, além de implementar `loadPrintParameters()` e `savePrintParameters()` em `server.js` para usar `findOne` / `updateOne` no Mongo (substituindo leituras/escritas em `data/*.json`).  
- Atualizei a UI administrativa em `public/params-panel.html` para remover o `limit: 25` forçado (usa `limit = null` para retornar todos os perfis quando acessado pelo painel) e marquei endpoints que passaram a exigir `ensureAdminAuthorized`.  
- Adicionei a dependência `jsonwebtoken` no `package.json` e executei instalação; commits e ajustes menores (async/await nas funções que salvam parâmetros) foram aplicados.

### Testing
- Executado `npm install` para instalar `jsonwebtoken` e dependências adicionais, a instalação concluiu com sucesso e sem vulnerabilidades críticas encontradas.  
- Iniciado o servidor com `MONGODB_URI` e `ADMIN_JWT_SECRET` (via env) e verificado que o processo sobe; quando o Mongo não está acessível o servidor inicia em modo de funcionalidade limitada (observado `MongoServerSelectionError`).  
- Tentativa de acesso ao painel com `curl -I http://127.0.0.1:3001/params-panel` retornou `HTTP 200`, confirmando que a rota de UI está servida após as mudanças.  
- Execução automatizada de captura com Playwright falhou por conexão recusada ao serviço em uma tentativa anterior (ambiente de testes sem Mongo/porta aberta), portanto a navegação completa não foi confirmada via headless browser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948da0d014c833393f7912932e527fe)