### PR TITLE
Add MongoDB mongoose schemas for core collections and validate legacy persistence/auth

### DIFF
--- a/models/schemas.js
+++ b/models/schemas.js
@@ -1,0 +1,128 @@
+import mongoose from 'mongoose';
+
+// Schema de Parâmetros de Impressão
+const ParametrosSchema = new mongoose.Schema({
+  userId: { type: String, required: true, index: true },
+  sessionId: { type: String, index: true },
+  userName: String,
+  resin: { type: String, required: true, index: true },
+  printer: { type: String, required: true, index: true },
+  parametros: {
+    layerHeight: String,
+    baseLayers: String,
+    exposureTime: String,
+    baseExposureTime: String,
+    transitionLayers: String,
+    uvOffDelay: String,
+    liftDistance: {
+      value1: String,
+      value2: String
+    },
+    liftSpeed: {
+      value1: String,
+      value2: String
+    },
+    retractSpeed: {
+      value1: String,
+      value2: String
+    }
+  },
+  createdAt: { type: Date, default: Date.now, index: true },
+  updatedAt: { type: Date, default: Date.now }
+});
+
+// Schema de Sugestões
+const SugestoesSchema = new mongoose.Schema({
+  userId: { type: String, required: true },
+  sessionId: { type: String, required: true },
+  suggestion: { type: String, required: true },
+  userName: String,
+  userPhone: String,
+  userEmail: String,
+  lastUserMessage: String,
+  lastBotReply: String,
+  status: {
+    type: String,
+    enum: ['pending', 'approved', 'rejected'],
+    default: 'pending',
+    index: true
+  },
+  createdAt: { type: Date, default: Date.now, index: true },
+  approvedBy: String,
+  approvedAt: Date,
+  rejectedBy: String,
+  rejectedAt: Date,
+  rejectionReason: String,
+  documentId: String
+});
+
+// Schema de Conversas (Histórico)
+const ConversasSchema = new mongoose.Schema({
+  sessionId: { type: String, required: true, index: true },
+  userName: String,
+  userPhone: String,
+  userEmail: String,
+  resin: String,
+  printer: String,
+  messages: [{
+    role: { type: String, enum: ['user', 'assistant', 'system'] },
+    content: String,
+    timestamp: { type: Date, default: Date.now }
+  }],
+  metadata: {
+    documentsFound: Number,
+    questionType: String,
+    sentiment: String,
+    urgency: String,
+    intelligenceMetrics: Object
+  },
+  resolved: { type: Boolean, default: false },
+  rating: Number,
+  feedback: String,
+  createdAt: { type: Date, default: Date.now, index: true },
+  updatedAt: { type: Date, default: Date.now }
+});
+
+// Schema de Métricas
+const MetricasSchema = new mongoose.Schema({
+  sessionId: { type: String, required: true, index: true },
+  userName: String,
+  userPhone: String,
+  userEmail: String,
+  message: String,
+  reply: String,
+  timestamp: { type: Date, default: Date.now, index: true },
+  documentsFound: Number,
+  questionType: String,
+  questionConfidence: Number,
+  entitiesDetected: Object,
+  sentiment: String,
+  urgency: String,
+  intelligenceMetrics: Object,
+  isImageAnalysis: Boolean,
+  imageDescription: String,
+  hasRelevantKnowledge: Boolean,
+  feedbackAdded: Boolean,
+  feedbackDocumentId: String,
+  markedAsBad: Boolean,
+  badResponseReason: String
+});
+
+const Parametros = mongoose.model('Parametros', ParametrosSchema);
+const Sugestoes = mongoose.model('Sugestoes', SugestoesSchema);
+const Conversas = mongoose.model('Conversas', ConversasSchema);
+const Metricas = mongoose.model('Metricas', MetricasSchema);
+
+export {
+  Parametros,
+  Sugestoes,
+  Conversas,
+  Metricas
+};
+
+export default {
+  Parametros,
+  Sugestoes,
+  Conversas,
+  Metricas
+};


### PR DESCRIPTION
### Motivation
- Implement the migration to MongoDB described in the technical report so in-memory/file persistence is replaced by persistent collections.  
- Provide ready-to-use Mongoose models for the core entities used by the RAG and admin flows.  
- Prepare the codebase for the planned JWT unification by identifying existing auth/persistence conflicts.  
- Reduce risk of data loss for print parameters, suggestions, conversations and metrics by centralizing schemas.

### Description
- Validated `server.js` and `db.js` for legacy persistence and auth patterns and documented findings such as in-memory arrays (`knowledgeSuggestions`, `customRequests`), a `fs.readFileSync` usage in `/rag-status`, and existing admin token handling via `ADMIN_JWT_SECRET`.  
- Added a new file `models/schemas.js` that defines and exports four Mongoose schemas and models: `Parametros`, `Sugestoes`, `Conversas`, and `Metricas`.  
- Each schema includes the fields, indexes and defaults called for in the migration plan (timestamps, indexed `sessionId`/`userId`, `status` enum for suggestions, messages array for conversations, and intelligence metrics).  
- Created the `models` directory and exported both named and default exports for straightforward import into existing code.

### Testing
- No automated unit/integration tests were executed because this is a schema-only change that does not modify runtime routes or logic.  
- Performed static validation and code inspection using targeted searches (`rg`) and file reads to detect potential conflicts in `server.js`/`db.js`, and found no blocking issues that prevent introducing the mongoose models.  
- File creation and basic repository operations succeeded (the file `models/schemas.js` was added).  
- Further automated tests (lint, unit, integration) should be run after wiring these models into the application and protecting admin routes with the JWT middleware.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948e19992b0833396102c8da8f2d5bf)