### PR TITLE
Add Mongoose models and wire DB connection for Phase 1

### DIFF
--- a/db.js
+++ b/db.js
@@ -2,6 +2,13 @@
 // Gerencia conexao unica com o banco de dados
 
 import { MongoClient } from 'mongodb';
+import mongoose from 'mongoose';
+import {
+  Parametros,
+  Sugestoes,
+  Conversas,
+  Metricas
+} from './models/schemas.js';
 
 // URI do MongoDB (OBRIGATORIO via variavel de ambiente)
 const MONGODB_URI = process.env.MONGODB_URI;
@@ -14,6 +21,7 @@ if (!MONGODB_URI) {
 
 let client = null;
 let db = null;
+let mongooseConnected = false;
 
 // Conectar ao MongoDB
 export async function connectToMongo() {
@@ -24,6 +32,11 @@ export async function connectToMongo() {
 
   try {
     console.log('[MongoDB] Conectando ao banco de dados...');
+    if (!mongooseConnected) {
+      await mongoose.connect(MONGODB_URI, { dbName: DB_NAME });
+      mongooseConnected = true;
+      console.log('[MongoDB] Conexao Mongoose estabelecida');
+    }
     client = new MongoClient(MONGODB_URI);
     await client.connect();
     db = client.db(DB_NAME);
@@ -111,6 +124,11 @@ export async function closeMongo() {
     db = null;
     console.log('[MongoDB] Conexao fechada');
   }
+  if (mongooseConnected) {
+    await mongoose.disconnect();
+    mongooseConnected = false;
+    console.log('[MongoDB] Conexao Mongoose fechada');
+  }
 }
 
 // Verificar status da conexao
@@ -128,6 +146,17 @@ export default {
   getSuggestionsCollection,
   getPartnersCollection,
   getPrintParametersCollection,
+  Parametros,
+  Sugestoes,
+  Conversas,
+  Metricas,
   closeMongo,
   isConnected
+};
+
+export {
+  Parametros,
+  Sugestoes,
+  Conversas,
+  Metricas
 };

--- a/models/schemas.js
+++ b/models/schemas.js
@@ -14,11 +14,19 @@ const ParametrosSchema = new mongoose.Schema({
     baseExposureTime: String,
     transitionLayers: String,
     uvOffDelay: String,
+    lowerLiftDistance: {
+      value1: String,
+      value2: String
+    },
     liftDistance: {
       value1: String,
       value2: String
     },
     liftSpeed: {
+      value1: String,
+      value2: String
+    },
+    lowerRetractSpeed: {
       value1: String,
       value2: String
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express-rate-limit": "^8.2.1",
         "jsonwebtoken": "^9.0.3",
         "mongodb": "^7.0.0",
+        "mongoose": "^8.20.4",
         "multer": "^1.4.5-lts.1",
         "openai": "^4.58.1"
       }
@@ -1350,6 +1351,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1610,6 +1620,186 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/mongoose": {
+      "version": "8.20.4",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.20.4.tgz",
+      "integrity": "sha512-o4ABeT3IEk1Z4dGt3XjHJ0x9OjyWvakC1+btPpzWqCovqyidKGdbB05/g87cdh7AuWXFQKHOxt+L/OZOBps4hw==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.10.4",
+        "kareem": "2.6.3",
+        "mongodb": "~6.20.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongoose/node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongoose/node_modules/mongodb": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongoose/node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongoose/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mongoose/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongoose/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/mquery/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mquery/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -2256,6 +2446,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "express-rate-limit": "^8.2.1",
     "jsonwebtoken": "^9.0.3",
     "mongodb": "^7.0.0",
+    "mongoose": "^8.20.4",
     "multer": "^1.4.5-lts.1",
     "openai": "^4.58.1"
   }


### PR DESCRIPTION
### Motivation
- Provide formal Mongoose schemas for Phase 1 models to capture print parameters, suggestions, conversations and metrics including exposure and elevation details. 
- Make those models available to the rest of the app by wiring a Mongoose connection and exporting the models from the DB layer. 
- Ensure the project has the `mongoose` dependency so schemas can be used by the server later.

### Description
- Extended `models/schemas.js` to include `lowerLiftDistance` and `lowerRetractSpeed` inside the `parametros` object and defined the `Parametros`, `Sugestoes`, `Conversas`, and `Metricas` Mongoose models. 
- Updated `db.js` to import the models and initialize a Mongoose connection via `mongoose.connect`, tracked with a `mongooseConnected` flag, and added named and default exports for the models. 
- Added Mongoose disconnect logic to `closeMongo()` while preserving the existing `MongoClient` connection logic and collection creation checks. 
- Added `mongoose` to `package.json` and updated `package-lock.json` (dependency installed in the workspace).

### Testing
- Ran `npm install mongoose@^8.10.2`, which completed successfully and reported packages were added with `0 vulnerabilities`. 
- No unit or integration test suite was executed after these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948e357bcf88333a645c1d081d6e22a)