### PR TITLE
Migrate print parameters & suggestions to MongoDB and add JWT admin authentication

### DIFF
--- a/admin-panel-test.html
+++ b/admin-panel-test.html
@@ -127,6 +127,17 @@
             border-radius: 5px;
             margin-bottom: 20px;
         }
+        .login {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+        .login input {
+            padding: 6px 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
     </style>
 </head>
 <body>
@@ -134,6 +145,12 @@
         <div class="header">
             <h1>🤖 Painel Admin - Quanton3D Bot</h1>
             <p>Teste Local - Gerenciamento de Sugestões</p>
+        </div>
+
+        <div class="login">
+            <input id="admin-password" type="password" placeholder="Senha admin">
+            <button class="btn btn-refresh" onclick="login()">Entrar</button>
+            <span id="login-status" class="suggestion-meta"></span>
         </div>
 
         <div id="rag-status" class="rag-status">
@@ -162,7 +179,48 @@
 
     <script>
         const API_BASE = 'http://localhost:3001';
-        const AUTH_TOKEN = 'quanton3d_admin_secret';
+        const AUTH_TOKEN_KEY = 'quanton3d_admin_token';
+        let authToken = localStorage.getItem(AUTH_TOKEN_KEY) || '';
+        const loginStatus = document.getElementById('login-status');
+        const passwordInput = document.getElementById('admin-password');
+
+        const setAuthToken = (token) => {
+            authToken = token;
+            if (token) {
+                localStorage.setItem(AUTH_TOKEN_KEY, token);
+                loginStatus.textContent = '✅ Autenticado';
+            } else {
+                localStorage.removeItem(AUTH_TOKEN_KEY);
+                loginStatus.textContent = '🔒 Não autenticado';
+            }
+        };
+
+        async function login() {
+            try {
+                const password = passwordInput.value;
+                if (!password) {
+                    showMessage('Informe a senha de admin.', 'error');
+                    return;
+                }
+                const response = await fetch(`${API_BASE}/admin/login`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ password })
+                });
+                const data = await response.json();
+                if (!data.success) {
+                    setAuthToken('');
+                    showMessage(data.message || 'Falha no login.', 'error');
+                    return;
+                }
+                setAuthToken(data.token);
+                showMessage('Login realizado com sucesso!', 'success');
+                await Promise.all([checkRAGStatus(), checkIntelligenceStats(), loadSuggestions()]);
+            } catch (error) {
+                console.error('Erro ao fazer login:', error);
+                showMessage('Erro ao fazer login.', 'error');
+            }
+        }
 
         // Função para mostrar mensagens
         function showMessage(message, type = 'success') {
@@ -176,7 +234,9 @@
         // Função para verificar status do RAG
         async function checkRAGStatus() {
             try {
-                const response = await fetch(`${API_BASE}/rag-status?auth=${AUTH_TOKEN}`);
+                const response = await fetch(`${API_BASE}/rag-status`, {
+                    headers: { Authorization: `Bearer ${authToken}` }
+                });
                 const data = await response.json();
 
                 if (data.success) {
@@ -201,7 +261,9 @@
         // Função para verificar estatísticas de inteligência
         async function checkIntelligenceStats() {
             try {
-                const response = await fetch(`${API_BASE}/intelligence-stats?auth=${AUTH_TOKEN}`);
+                const response = await fetch(`${API_BASE}/intelligence-stats`, {
+                    headers: { Authorization: `Bearer ${authToken}` }
+                });
                 const data = await response.json();
 
                 if (data.success && data.stats) {
@@ -247,7 +309,9 @@
             container.innerHTML = '';
 
             try {
-                const response = await fetch(`${API_BASE}/suggestions?auth=${AUTH_TOKEN}`);
+                const response = await fetch(`${API_BASE}/suggestions`, {
+                    headers: { Authorization: `Bearer ${authToken}` }
+                });
                 const data = await response.json();
 
                 loading.style.display = 'none';
@@ -299,10 +363,10 @@
 
                             <div class="actions">
                                 ${suggestion.status === 'pending' ? `
-                                    <button class="btn btn-approve" onclick="approveSuggestion(${suggestion.id})">
+                                    <button class="btn btn-approve" onclick="approveSuggestion('${suggestion.id}')">
                                         ✅ Aprovar
                                     </button>
-                                    <button class="btn btn-reject" onclick="rejectSuggestion(${suggestion.id})">
+                                    <button class="btn btn-reject" onclick="rejectSuggestion('${suggestion.id}')">
                                         ❌ Rejeitar
                                     </button>
                                 ` : `
@@ -335,11 +399,9 @@
                 const response = await fetch(`${API_BASE}/approve-suggestion/${suggestionId}`, {
                     method: 'PUT',
                     headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({
-                        auth: AUTH_TOKEN
-                    })
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${authToken}`
+                    }
                 });
 
                 const data = await response.json();
@@ -375,10 +437,10 @@
                 const response = await fetch(`${API_BASE}/reject-suggestion/${suggestionId}`, {
                     method: 'PUT',
                     headers: {
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${authToken}`
                     },
                     body: JSON.stringify({
-                        auth: AUTH_TOKEN,
                         reason: reason
                     })
                 });
@@ -402,9 +464,12 @@
 
         // Carregar dados ao inicializar
         document.addEventListener('DOMContentLoaded', function() {
-            loadSuggestions();
-            checkRAGStatus();
-            checkIntelligenceStats();
+            setAuthToken(authToken);
+            if (authToken) {
+                loadSuggestions();
+                checkRAGStatus();
+                checkIntelligenceStats();
+            }
         });
     </script>
 </body>

--- a/models/schemas.js
+++ b/models/schemas.js
@@ -37,7 +37,7 @@ const ParametrosSchema = new mongoose.Schema({
   },
   createdAt: { type: Date, default: Date.now, index: true },
   updatedAt: { type: Date, default: Date.now }
-});
+}, { collection: 'print_parameters' });
 
 // Schema de Sugestões
 const SugestoesSchema = new mongoose.Schema({
@@ -62,7 +62,7 @@ const SugestoesSchema = new mongoose.Schema({
   rejectedAt: Date,
   rejectionReason: String,
   documentId: String
-});
+}, { collection: 'suggestions' });
 
 // Schema de Conversas (Histórico)
 const ConversasSchema = new mongoose.Schema({


### PR DESCRIPTION
### Motivation

- Ensure print parameters and knowledge suggestions are persisted in MongoDB so data survives restarts and Render redeploys.
- Replace fragile file-based persistence (`fs.readFileSync`/`fs.writeFileSync`) with Mongoose-backed operations using the existing models.
- Harden admin endpoints by replacing the previous secret-based checks with short-lived JWTs and an `authenticateJWT` middleware.
- Provide a small local admin test UI flow that uses Bearer tokens instead of the old `quanton3d_admin_secret` query parameter.

### Description

- Replaced file-system parameter reads/writes with MongoDB operations via the `Parametros` Mongoose model (use `Parametros.collection.findOne` / `Parametros.collection.updateOne`) and migrated suggestions to use the `Sugestoes` model (`Sugestoes.create`, `Sugestoes.find`, `Sugestoes.updateOne`).
- Implemented JWT admin authentication: added `/admin/login` which validates `ADMIN_SECRET` and issues a JWT signed with `ADMIN_JWT_SECRET`, plus the `authenticateJWT` middleware used to protect admin routes.
- Applied `authenticateJWT` to administrative and edit endpoints (examples: `/suggestions`, `/approve-suggestion/:id`, `/reject-suggestion/:id`, `/params/*`, `/api/*` admin endpoints, gallery/visual RAG endpoints, metrics and partner admin endpoints), and added a helper `isAdminTokenValid` for admin-aware read-only flows.
- Updated `models/schemas.js` to set explicit collection names (`print_parameters` and `suggestions`) and adjusted code paths that previously used `getPrintParametersCollection()` to operate via the `Parametros` model collection.
- Updated `admin-panel-test.html` to support a login UI, call `/admin/login` to get a Bearer token and use that token when calling admin endpoints instead of the old `auth=` URL parameter.

### Testing

- Performed a local static-server smoke test with `python -m http.server 8000` and used Playwright to load `admin-panel-test.html` and capture a screenshot of the new login UI, which rendered successfully.
- Verified the server-side code compiles (no runtime invocation of the Node `server.js` was performed in this rollout).
- Performed basic manual checks in the codebase to ensure admin routes now require Bearer tokens and that suggestions are created with `Sugestoes.create` and read/updated with Mongoose queries.
- No automated test-suite was executed as part of this change; further integration tests (starting `server.js` with a test MongoDB and exercising endpoints) are recommended before production deploy.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948e46bb2948333ae52ba5bf8a1fe59)