### PR TITLE
Add seed script to import print parameters and suggestions into MongoDB Atlas

### DIFF
--- a/scripts/seed-mongo-atlas.js
+++ b/scripts/seed-mongo-atlas.js
@@ -1,0 +1,128 @@
+// Seed de dados para MongoDB Atlas
+// - Importa data/resins_extracted.json -> print_parameters
+// - Importa knowledge/suggestions.json -> suggestions
+
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import { MongoClient } from 'mongodb';
+
+dotenv.config();
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const DB_NAME = 'quanton3d';
+const PRINT_PARAMETERS_COLLECTION = 'print_parameters';
+const SUGGESTIONS_COLLECTION = 'suggestions';
+
+const PRINT_PARAMETERS_FILE = path.join(process.cwd(), 'data', 'resins_extracted.json');
+const SUGGESTIONS_FILE = path.join(process.cwd(), 'knowledge', 'suggestions.json');
+
+function ensureFileExists(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Arquivo nao encontrado: ${filePath}`);
+  }
+}
+
+function loadJson(filePath) {
+  ensureFileExists(filePath);
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function normalizeSuggestions(raw) {
+  if (Array.isArray(raw)) return raw;
+  if (Array.isArray(raw?.suggestions)) return raw.suggestions;
+  if (Array.isArray(raw?.data)) return raw.data;
+  return [];
+}
+
+async function seedPrintParameters(db) {
+  console.log('[1/3] Importando parametros de impressao...');
+  const data = loadJson(PRINT_PARAMETERS_FILE);
+
+  if (!Array.isArray(data?.profiles)) {
+    throw new Error('Estrutura invalida em data/resins_extracted.json: campo profiles ausente.');
+  }
+
+  const operations = data.profiles.map(profile => ({
+    updateOne: {
+      filter: { id: profile.id },
+      update: {
+        $set: {
+          ...profile,
+          updatedAt: new Date()
+        },
+        $setOnInsert: {
+          createdAt: new Date()
+        }
+      },
+      upsert: true
+    }
+  }));
+
+  if (operations.length === 0) {
+    console.log('⚠️ Nenhum perfil encontrado para importar.');
+    return;
+  }
+
+  const result = await db.collection(PRINT_PARAMETERS_COLLECTION).bulkWrite(operations, { ordered: false });
+  const total = await db.collection(PRINT_PARAMETERS_COLLECTION).countDocuments();
+  console.log(`✅ Perfis importados/atualizados: ${result.upsertedCount}/${operations.length}`);
+  console.log(`ℹ️ Total atual em print_parameters: ${total}`);
+}
+
+async function seedSuggestions(db) {
+  console.log('[2/3] Importando sugestoes...');
+  const raw = loadJson(SUGGESTIONS_FILE);
+  const suggestions = normalizeSuggestions(raw);
+
+  if (suggestions.length === 0) {
+    console.log('⚠️ Nenhuma sugestao encontrada para importar.');
+    return;
+  }
+
+  const operations = suggestions.map(suggestion => ({
+    updateOne: {
+      filter: suggestion.id != null ? { id: suggestion.id } : { suggestion: suggestion.suggestion },
+      update: {
+        $setOnInsert: {
+          ...suggestion,
+          createdAt: suggestion.createdAt || suggestion.timestamp || new Date()
+        }
+      },
+      upsert: true
+    }
+  }));
+
+  const result = await db.collection(SUGGESTIONS_COLLECTION).bulkWrite(operations, { ordered: false });
+  const total = await db.collection(SUGGESTIONS_COLLECTION).countDocuments();
+  console.log(`✅ Sugestoes importadas: ${result.upsertedCount}`);
+  console.log(`ℹ️ Total atual em suggestions: ${total}`);
+}
+
+async function runSeed() {
+  if (!MONGODB_URI) {
+    throw new Error('Defina a variavel MONGODB_URI antes de rodar o seed.');
+  }
+
+  console.log('='.repeat(60));
+  console.log('SEED IMEDIATO - QUANTON3D');
+  console.log('='.repeat(60));
+
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db(DB_NAME);
+
+  try {
+    await seedPrintParameters(db);
+    await seedSuggestions(db);
+    console.log('[3/3] Seed concluido com sucesso.');
+  } finally {
+    await client.close();
+  }
+}
+
+runSeed().catch(error => {
+  console.error('Erro no seed:', error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Provide a one-off seed to populate the `print_parameters` and `suggestions` collections in the `quanton3d` database on MongoDB Atlas.
- Reuse existing JSON exports so initial data can be quickly imported without manual record-by-record inserts.
- Ensure imports are idempotent by using upserts so the script can be re-run safely for recovery or migration.

### Description
- Added `scripts/seed-mongo-atlas.js` which reads `data/resins_extracted.json` and `knowledge/suggestions.json` and upserts them into `print_parameters` and `suggestions` respectively.
- Uses `bulkWrite` with `updateOne`/`upsert` operations and sets `createdAt`/`updatedAt` timestamps when inserting.
- Normalizes multiple suggestion file shapes (array, `{ suggestions: [...] }`, `{ data: [...] }`) before import.
- Requires `MONGODB_URI` environment variable and connects with `MongoClient` to perform the import and logs counts after writing.

### Testing
- Executed `node scripts/seed-mongo-atlas.js`, which aborted with an error because `MONGODB_URI` was not set (no connection attempted); test resulted in failure due to missing environment variable.
- No other automated tests were run against the new script in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694997efa19483338441623a7624f49b)