### PR TITLE
Add health check, rate limiting, and MongoDB indexes

### DIFF
--- a/db.js
+++ b/db.js
@@ -23,6 +23,18 @@ let client = null;
 let db = null;
 let mongooseConnected = false;
 
+async function ensureMongoIndexes() {
+  try {
+    await Parametros.createIndexes();
+    await Sugestoes.createIndexes();
+    await Conversas.createIndexes();
+    await Metricas.createIndexes();
+    console.log('[MongoDB] Indices garantidos para Parametros, Sugestoes, Conversas e Metricas');
+  } catch (err) {
+    console.warn('[MongoDB] Falha ao criar indices:', err.message);
+  }
+}
+
 // Conectar ao MongoDB
 export async function connectToMongo() {
   if (db) {
@@ -59,6 +71,8 @@ export async function connectToMongo() {
       await db.createCollection('print_parameters');
       console.log('[MongoDB] Colecao "print_parameters" criada');
     }
+
+    await ensureMongoIndexes();
     
     return db;
   } catch (err) {

--- a/models/schemas.js
+++ b/models/schemas.js
@@ -39,6 +39,9 @@ const ParametrosSchema = new mongoose.Schema({
   updatedAt: { type: Date, default: Date.now }
 }, { collection: 'print_parameters' });
 
+ParametrosSchema.index({ resin: 1, printer: 1, createdAt: -1 });
+ParametrosSchema.index({ sessionId: 1, createdAt: -1 });
+
 // Schema de Sugestões
 const SugestoesSchema = new mongoose.Schema({
   userId: { type: String, required: true },
@@ -63,6 +66,9 @@ const SugestoesSchema = new mongoose.Schema({
   rejectionReason: String,
   documentId: String
 }, { collection: 'suggestions' });
+
+SugestoesSchema.index({ status: 1, createdAt: -1 });
+SugestoesSchema.index({ sessionId: 1, createdAt: -1 });
 
 // Schema de Conversas (Histórico)
 const ConversasSchema = new mongoose.Schema({
@@ -91,6 +97,9 @@ const ConversasSchema = new mongoose.Schema({
   updatedAt: { type: Date, default: Date.now }
 });
 
+ConversasSchema.index({ sessionId: 1, createdAt: -1 });
+ConversasSchema.index({ userEmail: 1, createdAt: -1 });
+
 // Schema de Métricas
 const MetricasSchema = new mongoose.Schema({
   sessionId: { type: String, required: true, index: true },
@@ -115,6 +124,9 @@ const MetricasSchema = new mongoose.Schema({
   markedAsBad: Boolean,
   badResponseReason: String
 });
+
+MetricasSchema.index({ sessionId: 1, timestamp: -1 });
+MetricasSchema.index({ userEmail: 1, timestamp: -1 });
 
 const Parametros = mongoose.model('Parametros', ParametrosSchema);
 const Sugestoes = mongoose.model('Sugestoes', SugestoesSchema);


### PR DESCRIPTION
### Motivation
- Melhorar performance criando índices nas coleções de parâmetros, sugestões, conversas e métricas para acelerar consultas críticas.
- Aumentar a segurança do painel administrativo prevenindo ataques de força bruta na rota de login.
- Permitir monitoramento em tempo real do serviço e do banco de dados via endpoint de healthcheck `/health`.
- Garantir que os índices sejam aplicados automaticamente durante a inicialização da conexão com o MongoDB.

### Description
- Adiciona índices compostos e índices de consulta nos schemas em `models/schemas.js` para `Parametros`, `Sugestoes`, `Conversas` e `Metricas`.
- Implementa `ensureMongoIndexes()` em `db.js` e chama `createIndexes()` via Mongoose durante `connectToMongo()` para garantir a criação dos índices na inicialização.
- Reativa `express-rate-limit`, configura `app.set('trust proxy', 1)` e aplica o middleware `loginLimiter` na rota `POST /admin/login` com limite de `max: 5` tentativas por `15` minutos.
- Adiciona o endpoint `GET /health` em `server.js` que verifica `mongoose.connection.readyState` e executa um `db.admin().ping()` para retornar status `200` quando servidor e Mongo estão OK ou `503` quando degradado.

### Testing
- Nenhum teste automatizado foi executado para estas alterações.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a8b31f948333b650a2526adcb8ed)