### PR TITLE
Add radial FAB menu UI and serve it at root

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Quanton3D IA | Menu FAB Radial</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #020a1a;
+      --panel: rgba(4, 18, 44, 0.75);
+      --glow: #23b0ff;
+      --glow-strong: #5ad0ff;
+      --accent: #0a6cff;
+      --accent-soft: rgba(30, 144, 255, 0.35);
+      --text: #e6f5ff;
+      --shadow: 0 20px 60px rgba(8, 120, 255, 0.35);
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+      font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+    }
+
+    body {
+      min-height: 100vh;
+      background: radial-gradient(circle at top, rgba(42, 98, 255, 0.25), transparent 45%),
+        radial-gradient(circle at 20% 40%, rgba(0, 214, 255, 0.2), transparent 50%),
+        var(--bg);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--text);
+      padding: 32px 20px 140px;
+    }
+
+    .hud {
+      width: min(420px, 100%);
+      background: var(--panel);
+      border: 1px solid rgba(60, 160, 255, 0.35);
+      border-radius: 28px;
+      padding: 32px 28px 44px;
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(20px);
+    }
+
+    .hud h1 {
+      font-size: 1.5rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .hud p {
+      margin-top: 12px;
+      font-size: 0.95rem;
+      line-height: 1.6;
+      color: rgba(230, 245, 255, 0.75);
+    }
+
+    .fab-container {
+      position: fixed;
+      right: 28px;
+      bottom: 28px;
+      width: 180px;
+      height: 180px;
+      pointer-events: none;
+      z-index: 40;
+    }
+
+    .fab-center {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      width: 76px;
+      height: 76px;
+      border-radius: 50%;
+      border: 1px solid rgba(90, 208, 255, 0.7);
+      background: linear-gradient(140deg, rgba(31, 169, 255, 0.9), rgba(5, 76, 191, 0.95));
+      box-shadow: 0 0 25px rgba(66, 190, 255, 0.9),
+        inset 0 0 18px rgba(255, 255, 255, 0.2);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #f5fbff;
+      font-size: 0.9rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      cursor: pointer;
+      pointer-events: auto;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    .fab-center::before {
+      content: "";
+      position: absolute;
+      inset: 8px;
+      border-radius: 50%;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      opacity: 0.7;
+    }
+
+    .fab-center:hover {
+      transform: scale(1.05);
+      box-shadow: 0 0 35px rgba(90, 208, 255, 1), inset 0 0 20px rgba(255, 255, 255, 0.25);
+    }
+
+    .fab-actions {
+      position: absolute;
+      right: 8px;
+      bottom: 8px;
+      width: 160px;
+      height: 160px;
+      pointer-events: none;
+    }
+
+    .fab-action {
+      position: absolute;
+      width: 64px;
+      height: 64px;
+      border-radius: 50%;
+      border: 1px solid rgba(90, 208, 255, 0.45);
+      background: linear-gradient(160deg, rgba(13, 88, 209, 0.95), rgba(2, 30, 72, 0.95));
+      box-shadow: 0 0 18px rgba(35, 176, 255, 0.6);
+      color: var(--text);
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-align: center;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      flex-direction: column;
+      opacity: 0;
+      transform: scale(0.4);
+      transition: transform 0.35s ease, opacity 0.35s ease;
+      pointer-events: auto;
+    }
+
+    .fab-action span {
+      font-size: 0.55rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .fab-action svg {
+      width: 22px;
+      height: 22px;
+      fill: currentColor;
+      filter: drop-shadow(0 0 6px rgba(90, 208, 255, 0.8));
+    }
+
+    .fab-container.open .fab-action {
+      opacity: 1;
+      transform: scale(1);
+      pointer-events: auto;
+    }
+
+    .fab-action.parametros { transform: translate(-10px, -110px); }
+    .fab-action.busca { transform: translate(-85px, -85px); }
+    .fab-action.whatsapp { transform: translate(-110px, -10px); }
+    .fab-action.metricas { transform: translate(-45px, -135px); }
+
+    .fab-container.open .fab-action.parametros { transform: translate(-10px, -110px); }
+    .fab-container.open .fab-action.busca { transform: translate(-85px, -85px); }
+    .fab-container.open .fab-action.whatsapp { transform: translate(-110px, -10px); }
+    .fab-container.open .fab-action.metricas { transform: translate(-45px, -135px); }
+
+    .fab-container:not(.open) .fab-action {
+      transform: translate(0, 0) scale(0.4);
+      opacity: 0;
+    }
+
+    .fab-action::after {
+      content: "";
+      position: absolute;
+      inset: 6px;
+      border-radius: 50%;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+    }
+
+    .fab-action:hover {
+      box-shadow: 0 0 24px rgba(90, 208, 255, 0.9), inset 0 0 18px rgba(18, 160, 255, 0.35);
+      transform: translate(var(--tx), var(--ty)) scale(1.05);
+    }
+
+    .fab-shadow-ring {
+      position: absolute;
+      right: -30px;
+      bottom: -30px;
+      width: 140px;
+      height: 140px;
+      border-radius: 50%;
+      border: 1px solid rgba(35, 176, 255, 0.35);
+      opacity: 0.45;
+      filter: blur(0.4px);
+      pointer-events: none;
+    }
+
+    .fab-container.open .fab-shadow-ring {
+      animation: pulse 2.6s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { transform: scale(0.98); opacity: 0.45; }
+      50% { transform: scale(1.08); opacity: 0.75; }
+    }
+
+    @media (max-width: 480px) {
+      .fab-container {
+        right: 20px;
+        bottom: 20px;
+        width: 160px;
+        height: 160px;
+      }
+
+      .fab-center {
+        width: 70px;
+        height: 70px;
+        font-size: 0.8rem;
+      }
+
+      .fab-action {
+        width: 58px;
+        height: 58px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="hud">
+    <h1>Modo Live • Astra UI</h1>
+    <p>
+      Menu de acesso rápido ativado para operações essenciais. Toque no núcleo para
+      expandir as funções em modo radial futurista.
+    </p>
+  </div>
+
+  <div class="fab-container" id="fabMenu" aria-label="Menu de ações rápidas">
+    <div class="fab-shadow-ring"></div>
+    <div class="fab-actions">
+      <button class="fab-action parametros" type="button" aria-label="Abrir parâmetros">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.32a.5.5 0 0 0-.6-.22l-2.39.96a7.14 7.14 0 0 0-1.62-.94l-.36-2.54A.5.5 0 0 0 13.9 2h-3.8a.5.5 0 0 0-.49.41l-.36 2.54c-.58.23-1.12.54-1.62.94l-2.39-.96a.5.5 0 0 0-.6.22L2.72 8.42a.5.5 0 0 0 .12.64l2.03 1.58c-.05.3-.07.62-.07.94 0 .33.02.64.07.94l-2.03 1.58a.5.5 0 0 0-.12.64l1.92 3.32c.13.22.39.31.6.22l2.39-.96c.5.4 1.04.72 1.62.94l.36 2.54c.04.24.25.41.49.41h3.8c.24 0 .45-.17.49-.41l.36-2.54c.58-.23 1.12-.54 1.62-.94l2.39.96c.22.09.47 0 .6-.22l1.92-3.32a.5.5 0 0 0-.12-.64l-2.03-1.58Zm-7.14 2.56a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Z" />
+        </svg>
+        <span>Parâmetros</span>
+      </button>
+      <button class="fab-action busca" type="button" aria-label="Abrir busca">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M10 2a8 8 0 1 0 5.29 14.04l4.34 4.34 1.41-1.41-4.34-4.34A8 8 0 0 0 10 2Zm0 2a6 6 0 1 1 0 12 6 6 0 0 1 0-12Z" />
+        </svg>
+        <span>Busca</span>
+      </button>
+      <button class="fab-action whatsapp" type="button" aria-label="Abrir WhatsApp">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M20.52 3.5A11.8 11.8 0 0 0 12.02 0C5.4 0 .04 5.36.04 11.98a11.9 11.9 0 0 0 1.59 5.92L0 24l6.27-1.6a12 12 0 0 0 5.75 1.46h.01c6.62 0 12-5.36 12-11.98a11.8 11.8 0 0 0-3.51-8.38ZM12.02 22a10 10 0 0 1-5.1-1.4l-.37-.22-3.72.95 1-3.63-.24-.38a10 10 0 1 1 8.43 4.68Zm5.52-7.4c-.3-.15-1.77-.87-2.05-.97-.27-.1-.47-.15-.67.15s-.77.97-.94 1.17c-.17.2-.35.22-.65.07-.3-.15-1.27-.47-2.42-1.5-.9-.8-1.5-1.8-1.67-2.1-.17-.3-.02-.46.13-.6.14-.14.3-.35.45-.52.15-.17.2-.3.3-.5.1-.2.05-.37-.02-.52-.07-.15-.67-1.6-.92-2.2-.24-.58-.48-.5-.67-.5h-.57c-.2 0-.52.07-.8.37s-1.05 1.03-1.05 2.5 1.08 2.9 1.23 3.1c.15.2 2.12 3.25 5.13 4.55.72.31 1.28.5 1.71.64.72.23 1.37.2 1.88.12.57-.09 1.77-.72 2.02-1.41.25-.7.25-1.3.17-1.41-.08-.12-.27-.2-.57-.35Z" />
+        </svg>
+        <span>WhatsApp</span>
+      </button>
+      <button class="fab-action metricas" type="button" aria-label="Abrir métricas">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M3 3h2v18H3V3Zm6 7h2v11H9V10Zm6-4h2v15h-2V6Zm6 8h2v7h-2v-7Z" />
+        </svg>
+        <span>Métricas</span>
+      </button>
+    </div>
+    <button class="fab-center" type="button" id="fabToggle" aria-expanded="false">
+      Menu
+    </button>
+  </div>
+
+  <script>
+    const fabMenu = document.getElementById("fabMenu");
+    const fabToggle = document.getElementById("fabToggle");
+    const actionButtons = fabMenu.querySelectorAll(".fab-action");
+
+    const toggleMenu = () => {
+      const isOpen = fabMenu.classList.toggle("open");
+      fabToggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+    };
+
+    fabToggle.addEventListener("click", toggleMenu);
+
+    actionButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        fabMenu.classList.remove("open");
+        fabToggle.setAttribute("aria-expanded", "false");
+      });
+    });
+
+    document.addEventListener("click", (event) => {
+      if (!fabMenu.contains(event.target)) {
+        fabMenu.classList.remove("open");
+        fabToggle.setAttribute("aria-expanded", "false");
+      }
+    });
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ app.get("/params-panel", (req, res) => {
 });
 
 app.get("/", (req, res) => {
-  res.send("🚀 Quanton3D IA Online! Astra no comando estratégico. Tudo pronto, pai Ronei!");
+  res.sendFile(path.join(publicDir, 'index.html'));
 });
 
 app.post("/admin/login", async (req, res) => {


### PR DESCRIPTION
### Motivation
- Implement the Phase 2.4 live UI: a futuristic blue radial FAB (floating action button) with four quick actions (Parâmetros, Busca, WhatsApp, Métricas) optimized visually for mobile (Samsung S24 Ultra).
- Provide an interactive, accessible landing page to replace the previous plain text root response and make the UI reachable from the server root.

### Description
- Added `public/index.html` containing the full HTML/CSS/JS implementation of the radial FAB menu with SVG icons, responsive styles, and open/close animations.
- Implemented keyboard/ARIA-friendly toggling and click-to-close behavior in the page JavaScript for basic accessibility.
- Updated `server.js` root route to serve the new `index.html` via `res.sendFile(path.join(publicDir, 'index.html'))`.

### Testing
- Started a local static server and confirmed `GET /index.html` returned `200 OK` using `curl -I`, which succeeded.
- Performed a DOM smoke check with `curl -s` to verify `#fabToggle` exists in the served markup, which succeeded.
- Executed Playwright screenshot scripts: initial runs timed out, but a subsequent Playwright run produced page screenshots successfully, validating rendering and toggle behavior (partial transient failures followed by a successful run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949ecec6d0083339d03e58bf781cca9)