### PR TITLE
Enable admin routes and static assets; bind server to 0.0.0.0 for Render

### DIFF
--- a/admin/security.js
+++ b/admin/security.js
@@ -29,6 +29,7 @@ function verifySSE(req, res, next, jwtSecret){
 function attachAdminSecurity(app){
   const ADMIN_SECRET = process.env.ADMIN_SECRET;
   const ADMIN_JWT_SECRET = process.env.ADMIN_JWT_SECRET;
+  const ADMIN_USERNAME = process.env.ADMIN_USERNAME || "admin";
   const ALLOWED = allowListFromEnv(process.env.CORS_ORIGIN);
 
   if (!ADMIN_SECRET || !ADMIN_JWT_SECRET) {
@@ -50,8 +51,11 @@ function attachAdminSecurity(app){
 
   // POST /admin/login → troca senha por JWT curto
   app.post("/admin/login", (req, res) => {
-    const { password } = req.body || {};
+    const { username, password } = req.body || {};
     if (!password) return res.status(400).json({ error: "password_required" });
+    if (username && username !== ADMIN_USERNAME) {
+      return res.status(401).json({ error: "bad_credentials" });
+    }
     if (password !== ADMIN_SECRET) return res.status(401).json({ error: "bad_credentials" });
     return res.json({ token: issueToken(ADMIN_JWT_SECRET), expiresIn: 1800 });
   });


### PR DESCRIPTION
### Motivation
- Corrigir erro 502 e rotas não encontradas garantindo que rotas estáticas e administrativas sejam servidas pelo servidor.
- Ativar o módulo de segurança admin para aplicar login JWT, rate limiting e SSE autenticado.
- Garantir que o processo escute em interfaces externas para compatibilidade com o ambiente Render.

### Description
- Importa e chama `attachAdminSecurity(app)` para ativar as rotas `/admin/*` preservando CORS, rate limit e SSE protegido.
- Serve arquivos estáticos com `app.use(express.static(publicDir))` e expõe um painel de administração de teste em `/admin-panel` com `admin-panel-test.html`.
- Remove duplicação de rota de login em `server.js` e passa a usar o fluxo de login centralizado em `admin/security.js`, que agora aceita `username` opcional e valida `ADMIN_USERNAME` via env.
- Altera `app.listen` para `app.listen(PORT, "0.0.0.0", ...)` e adiciona log de erro no startup para facilitar diagnóstico no Render.

### Testing
- Nenhum teste automatizado foi executado durante esta alteração.
- As modificações foram aplicadas e os arquivos `server.js` e `admin/security.js` foram atualizados e comitados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949ef928880833394918767580da53d)