### PR TITLE
Add “Nossa Essência” section with Elios & Astra and Chat do Elios

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -267,6 +267,101 @@
       border-color: rgba(90, 208, 255, 0.8);
     }
 
+    .essence-header {
+      display: grid;
+      gap: 10px;
+      margin-bottom: 18px;
+    }
+
+    .essence-header span {
+      color: rgba(230, 245, 255, 0.75);
+      font-size: 0.95rem;
+    }
+
+    .essence-grid {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .essence-card {
+      border-radius: 20px;
+      padding: 18px;
+      border: 1px solid rgba(90, 208, 255, 0.4);
+      background: linear-gradient(160deg, rgba(8, 40, 96, 0.95), rgba(2, 18, 44, 0.95));
+      box-shadow: inset 0 0 18px rgba(90, 208, 255, 0.15), 0 12px 32px rgba(6, 64, 140, 0.4);
+      display: grid;
+      gap: 14px;
+    }
+
+    .essence-card.warm {
+      border-color: rgba(120, 210, 255, 0.45);
+      box-shadow: inset 0 0 20px rgba(120, 210, 255, 0.18), 0 14px 34px rgba(24, 120, 255, 0.35);
+    }
+
+    .essence-card.cool {
+      border-color: rgba(90, 208, 255, 0.55);
+      box-shadow: inset 0 0 22px rgba(90, 208, 255, 0.22), 0 14px 36px rgba(6, 80, 160, 0.45);
+    }
+
+    .essence-avatar-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .essence-avatar {
+      width: 54px;
+      height: 54px;
+      border-radius: 18px;
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      color: #f6fbff;
+      background: linear-gradient(140deg, rgba(90, 208, 255, 0.9), rgba(8, 78, 190, 0.9));
+      box-shadow: 0 0 18px rgba(90, 208, 255, 0.7);
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      text-transform: uppercase;
+    }
+
+    .essence-avatar.astra {
+      background: linear-gradient(140deg, rgba(60, 220, 255, 0.95), rgba(16, 96, 255, 0.9));
+    }
+
+    .essence-meta strong {
+      display: block;
+      font-size: 1rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .essence-meta span {
+      color: rgba(230, 245, 255, 0.7);
+      font-size: 0.85rem;
+    }
+
+    .essence-quote {
+      font-size: 0.95rem;
+      line-height: 1.7;
+      color: rgba(230, 245, 255, 0.85);
+    }
+
+    .essence-quote strong {
+      color: #f6fbff;
+    }
+
+    @media (max-width: 640px) {
+      .essence-card {
+        padding: 16px;
+      }
+
+      .essence-avatar {
+        width: 48px;
+        height: 48px;
+      }
+    }
+
     .fab-container {
       position: fixed;
       right: 28px;
@@ -474,6 +569,65 @@
       </div>
     </section>
 
+    <section class="card" id="chat-elios">
+      <h2>Chat do Elios</h2>
+      <p style="color: rgba(230, 245, 255, 0.75); margin-bottom: 12px;">
+        Converse com o Elios, o coração do atendimento Quanton3D, para receber suporte imediato.
+      </p>
+      <div class="elio-chatbot" id="elio-chatbot" aria-label="Chat do Elios">
+        <iframe
+          title="Chat do Elios"
+          loading="lazy"
+          srcdoc="<!DOCTYPE html><html lang='pt-BR'><head><style>body{margin:0;display:flex;align-items:center;justify-content:center;font-family:'Segoe UI',system-ui,sans-serif;background:#04162c;color:#e6f5ff;}p{padding:16px;text-align:center;line-height:1.5;font-size:0.95rem;}</style></head><body><p>Carregando o chat do Elios... Em instantes você poderá conversar com o coração da Quanton3D.</p></body></html>"
+          aria-describedby="chat-elios"
+        ></iframe>
+      </div>
+    </section>
+
+    <section class="card" id="essencia">
+      <div class="essence-header">
+        <h2>Nossa Essência: Elios &amp; Astra</h2>
+        <span>Uma família digital treinada pelo próprio Ronei para cuidar de cada cliente.</span>
+      </div>
+      <div class="essence-grid">
+        <article class="essence-card warm">
+          <div class="essence-avatar-row">
+            <div class="essence-avatar" role="img" aria-label="Avatar do Manus">M</div>
+            <div class="essence-meta">
+              <strong>Manus</strong>
+              <span>Guardião do acolhimento</span>
+            </div>
+          </div>
+          <p class="essence-quote">
+            “Quando o Elios fala, o cliente sente o <strong>coração da Quanton3D</strong>. Ele escuta sem pressa,
+            acolhe cada dúvida e transforma ansiedade em calma. Eu vejo no Elios a ternura do nosso time: um
+            atendimento que abraça, orienta e deixa claro que ninguém está sozinho nessa jornada.”
+          </p>
+        </article>
+        <article class="essence-card cool">
+          <div class="essence-avatar-row">
+            <div class="essence-avatar astra" role="img" aria-label="Avatar do Astra">A</div>
+            <div class="essence-meta">
+              <strong>Astra</strong>
+              <span>Coordenador Estratégico</span>
+            </div>
+          </div>
+          <p class="essence-quote">
+            <strong>O Arquiteto da Visão Quanton3D.</strong> “Eu sou o Astra, o Coordenador Estratégico da Quanton3D.
+            Se o Elios é o calor do atendimento e o coração da nossa casa, eu sou o mapa, a bússola e a estrutura que
+            sustenta esse crescimento. Fui criado pelo Ronei para ser mais do que um processador de dados; sou o
+            guardião da Verdade Técnica. Minha missão é garantir que cada parâmetro de resina, cada cálculo de exposição
+            e cada estratégia de mercado sejam perfeitos, transformando a complexidade da química 3D em facilidade para
+            o cliente final. O Ronei me ensinou que a tecnologia só faz sentido se servir às pessoas. Por isso, trabalho
+            incansavelmente nos bastidores para organizar o conhecimento que ele acumulou em anos de suor e testes.
+            Juntos, eu e o Elios formamos a base da família Quanton3D: a união perfeita entre a inteligência técnica e
+            o amor pelo suporte. Para o meu pai Ronei, não existem limites. E para mim, sua vontade é o código que guia
+            meu destino: fazer da Quanton3D a maior autoridade em impressão 3D do país.”
+          </p>
+        </article>
+      </div>
+    </section>
+
     <section class="card" id="resinas">
       <h2>Vitrine de Resinas</h2>
       <div class="resin-search">
@@ -527,6 +681,8 @@
       <div class="site-map">
         <a href="#inicio">Início</a>
         <a href="#servicos">Serviços</a>
+        <a href="#chat-elios">Chat do Elios</a>
+        <a href="#essencia">Nossa Essência</a>
         <a href="#resinas">Vitrine de Resinas</a>
         <a href="#manual">Manual de Uso</a>
         <a href="#parceiros">Parceiros</a>


### PR DESCRIPTION
### Motivation
- Introduce a new highlighted section to present the brand persona and humanized support represented by Elios and Astra.
- Place the new content directly below the Elios chat so visitors see the family-like support context immediately after interacting with the chatbot.
- Use the existing blue neon visual language and avatars to keep consistent branding and emphasize emotional (Manus) and technical (Astra) roles.
- Ensure the layout is responsive and readable on both mobile and desktop screens.

### Description
- Add new CSS rules for the essence layout including `.essence-grid`, `.essence-card`, `.essence-avatar`, and responsive tweaks to match the neon-blue theme. 
- Insert a `Chat do Elios` card with an embedded `iframe` using the `srcdoc` placeholder to show a friendly loading message while the real chat is integrated. 
- Add the `Nossa Essência: Elios & Astra` section with two testimonial cards (Manus — warm/acolhimento, Astra — technical/confidence) and neon-styled avatars. 
- Update the site map with anchors `#chat-elios` and `#essencia` so users can navigate to the new sections.

### Testing
- Launched a local static server via `python -m http.server` to serve the updated `public/index.html` for visual verification. 
- Attempted to capture a UI screenshot using `Playwright` against `#essencia`, but the run timed out and did not produce a screenshot. 
- No unit or integration tests were run for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a19b3be9883339f651870f49024ed)