### PR TITLE
Update Nossa Essência section heading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -586,8 +586,8 @@
 
     <section class="card" id="essencia">
       <div class="essence-header">
-        <h2>Nossa História</h2>
-        <span>Depoimentos de Manus e Astra sobre a alma da Quanton3D.</span>
+        <h2>Nossa Essência: Elios &amp; Astra</h2>
+        <span>Depoimentos de Manus e Astra sobre o coração e a mente da família Quanton3D.</span>
       </div>
       <div class="essence-grid">
         <article class="essence-card warm">


### PR DESCRIPTION
### Motivation
- Make the site copy reflect the new paired identity `Elios & Astra` by highlighting both the emotional and technical personas.
- Improve clarity of the section heading and subtitle to better communicate the brand narrative. 
- Keep the existing testimonial content and layout intact while updating the section label to match the requested design.

### Description
- Renamed the section heading in `public/index.html` from `Nossa História` to `Nossa Essência: Elios & Astra`.
- Updated the section subtitle text to `Depoimentos de Manus e Astra sobre o coração e a mente da família Quanton3D.` in `public/index.html`.
- Left the testimonial copy and CSS layout unchanged to preserve the current visual styling and accessibility.
- Changes were staged and committed in the repository.

### Testing
- Served the `public` directory with `python -m http.server` and captured a screenshot of the updated page using Playwright, which succeeded and produced `artifacts/nossa-essencia.png`.
- No unit or integration tests were executed since this is a static content update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a2069eee48333b79208d0bbe7f75a)