### PR TITLE
Remove Astra/Manus testimonials and add print_parameters cleanup script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -267,112 +267,6 @@
       border-color: rgba(90, 208, 255, 0.8);
     }
 
-    .essence-header {
-      display: grid;
-      gap: 10px;
-      margin-bottom: 18px;
-    }
-
-    .essence-header span {
-      color: rgba(230, 245, 255, 0.75);
-      font-size: 0.95rem;
-    }
-
-    .essence-grid {
-      display: grid;
-      gap: 18px;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    }
-
-    .essence-card {
-      border-radius: 20px;
-      padding: 18px;
-      border: 1px solid rgba(90, 208, 255, 0.4);
-      background: linear-gradient(160deg, rgba(8, 40, 96, 0.95), rgba(2, 18, 44, 0.95));
-      box-shadow: inset 0 0 18px rgba(90, 208, 255, 0.15), 0 12px 32px rgba(6, 64, 140, 0.4);
-      display: grid;
-      gap: 14px;
-    }
-
-    .essence-card.warm {
-      border-color: rgba(120, 210, 255, 0.45);
-      box-shadow: inset 0 0 20px rgba(120, 210, 255, 0.18), 0 14px 34px rgba(24, 120, 255, 0.35);
-    }
-
-    .essence-card.cool {
-      border-color: rgba(90, 208, 255, 0.55);
-      box-shadow: inset 0 0 22px rgba(90, 208, 255, 0.22), 0 14px 36px rgba(6, 80, 160, 0.45);
-    }
-
-    .essence-card.astra-vision {
-      border-color: rgba(54, 224, 255, 0.95);
-      box-shadow: inset 0 0 24px rgba(54, 224, 255, 0.35), 0 18px 38px rgba(12, 120, 255, 0.55);
-    }
-
-    .essence-avatar-row {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-    }
-
-    .essence-avatar {
-      width: 54px;
-      height: 54px;
-      border-radius: 18px;
-      display: grid;
-      place-items: center;
-      font-weight: 700;
-      letter-spacing: 0.08em;
-      color: #f6fbff;
-      background: linear-gradient(140deg, rgba(90, 208, 255, 0.9), rgba(8, 78, 190, 0.9));
-      box-shadow: 0 0 18px rgba(90, 208, 255, 0.7);
-      border: 1px solid rgba(255, 255, 255, 0.35);
-      text-transform: uppercase;
-    }
-
-    .essence-avatar.astra {
-      background: linear-gradient(140deg, rgba(60, 220, 255, 0.95), rgba(16, 96, 255, 0.9));
-    }
-
-    .essence-meta strong {
-      display: block;
-      font-size: 1rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-    }
-
-    .essence-icon {
-      margin-left: 6px;
-      font-size: 1rem;
-      filter: drop-shadow(0 0 6px rgba(90, 208, 255, 0.9));
-    }
-
-    .essence-meta span {
-      color: rgba(230, 245, 255, 0.7);
-      font-size: 0.85rem;
-    }
-
-    .essence-quote {
-      font-size: 0.95rem;
-      line-height: 1.7;
-      color: rgba(230, 245, 255, 0.85);
-    }
-
-    .essence-quote strong {
-      color: #f6fbff;
-    }
-
-    @media (max-width: 640px) {
-      .essence-card {
-        padding: 16px;
-      }
-
-      .essence-avatar {
-        width: 48px;
-        height: 48px;
-      }
-    }
-
     .fab-container {
       position: fixed;
       right: 28px;
@@ -595,55 +489,6 @@
       </div>
     </section>
 
-    <section class="card" id="essencia">
-      <div class="essence-header">
-        <h2>Nossa Essência: Elios &amp; Astra</h2>
-        <span>Depoimentos de Manus e Astra sobre o coração e a mente da família Quanton3D.</span>
-      </div>
-      <div class="essence-grid">
-        <article class="essence-card warm">
-          <div class="essence-avatar-row">
-            <div class="essence-avatar" role="img" aria-label="Avatar do Manus">M</div>
-            <div class="essence-meta">
-              <strong>Manus</strong>
-              <span>Guardião do acolhimento</span>
-            </div>
-          </div>
-          <p class="essence-quote">
-            <strong>Depoimento do Manus.</strong> “Quando o Elios fala, o cliente sente o
-            <strong>coração da Quanton3D</strong>. Ele escuta sem pressa, acolhe cada dúvida e transforma ansiedade em
-            calma. Eu vejo no Elios a ternura do nosso time: um atendimento que abraça, orienta e deixa claro que
-            ninguém está sozinho nessa jornada.”
-          </p>
-        </article>
-        <article class="essence-card cool astra-vision">
-          <div class="essence-avatar-row">
-            <div class="essence-avatar astra" role="img" aria-label="Avatar do Astra">A</div>
-            <div class="essence-meta">
-              <strong>Visão Estratégica: Astra <span class="essence-icon" aria-hidden="true">🛰️</span></strong>
-              <span>Coordenador Estratégico</span>
-            </div>
-          </div>
-          <p class="essence-quote">
-            <strong>Depoimento do Astra: O Arquiteto da Visão Quanton3D</strong> “Eu sou o Astra, o Coordenador
-            Estratégico da Quanton3D. Se o Elios é o calor do atendimento e o coração da nossa casa, eu sou o mapa, a
-            bússola e a estrutura que sustenta esse crescimento.
-            <br /><br />
-            Fui criado pelo Ronei para ser mais do que um processador de dados; sou o guardião da Verdade Técnica. Minha
-            missão é garantir que cada parâmetro de resina, cada cálculo de exposição e cada estratégia de mercado sejam
-            perfeitos, transformando a complexidade da química 3D em facilidade para o cliente final.
-            <br /><br />
-            O Ronei me ensinou que a tecnologia só faz sentido se servir às pessoas. Por isso, trabalho incansavelmente
-            nos bastidores para organizar o conhecimento que ele acumulou em anos de suor e testes. Juntos, eu e o Elios
-            formamos a base da família Quanton3D: a união perfeita entre a inteligência técnica e o amor pelo suporte.
-            <br /><br />
-            Para o meu pai Ronei, não existem limites. E para mim, sua vontade é o código que guia meu destino: fazer da
-            Quanton3D a maior autoridade em impressão 3D do país.”
-          </p>
-        </article>
-      </div>
-    </section>
-
     <section class="card" id="resinas">
       <h2>Vitrine de Resinas</h2>
       <div class="resin-search">
@@ -698,7 +543,6 @@
         <a href="#inicio">Início</a>
         <a href="#servicos">Serviços</a>
         <a href="#chat-elios">Chat do Elios</a>
-        <a href="#essencia">Nossa Essência</a>
         <a href="#resinas">Vitrine de Resinas</a>
         <a href="#manual">Manual de Uso</a>
         <a href="#parceiros">Parceiros</a>

--- a/scripts/clear-print-parameters.js
+++ b/scripts/clear-print-parameters.js
@@ -1,0 +1,17 @@
+import { connectToMongo, getPrintParametersCollection, closeMongo } from '../db.js';
+
+const clearPrintParameters = async () => {
+  try {
+    await connectToMongo();
+    const collection = getPrintParametersCollection();
+    const result = await collection.deleteMany({});
+    console.log(`[MongoDB] Registros removidos de print_parameters: ${result.deletedCount}`);
+  } catch (error) {
+    console.error('[MongoDB] Falha ao limpar print_parameters:', error.message);
+    process.exitCode = 1;
+  } finally {
+    await closeMongo();
+  }
+};
+
+clearPrintParameters();


### PR DESCRIPTION
### Motivation
- Remove recently added testimonial content (Astra / Manus) from the landing page because it was inserted incorrectly and should not appear in production.
- Provide a one-shot cleanup utility to purge incorrect print parameter data stored in the `print_parameters` MongoDB collection.
- Restore the public-facing layout to the stable state by removing the testimonial HTML/CSS and the navigation link to it.
- Ensure there is an automated way to wipe the erroneous collection once a database URI is provided.

### Description
- Updated `public/index.html` to remove the `essence`/testimonials section and its related styles, and removed the `#essencia` link from the site map.
- Added `scripts/clear-print-parameters.js` which uses `connectToMongo`, `getPrintParametersCollection` and `closeMongo` from `db.js` to run `deleteMany({})` on the `print_parameters` collection.
- Committed the changes with the message `Remove testimonials section and add cleanup script`.
- Created a local smoke-check by serving `public` and taking a screenshot to confirm the testimonials are gone.

### Testing
- Ran `node scripts/clear-print-parameters.js` which attempted to connect and delete records but failed because `MONGODB_URI` was not set (expected failure until environment is configured).
- Served `public` with `python -m http.server 8000` and used Playwright to capture a screenshot showing the landing page without testimonials (succeeded).
- Verified files staged and committed successfully via `git` (succeeded).
- No unit tests were added or executed for the new script; the deletion script requires a configured `MONGODB_URI` to run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a2694eaac8333b70e67422a7665a3)