### PR TITLE
Fix HTML parameter mapping, clear MongoDB seeds, and force testimonials visible

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,11 @@
       gap: 32px;
     }
 
+    .secao-familia {
+      display: flex !important;
+      visibility: visible !important;
+    }
+
     .hud {
       background: var(--panel);
       border: 1px solid rgba(60, 160, 255, 0.35);

--- a/scripts/migrate-final-data.js
+++ b/scripts/migrate-final-data.js
@@ -99,6 +99,12 @@ async function migratePrintParameters(db) {
 
 }
 
+async function clearCollections(db) {
+  const printResult = await db.collection(PRINT_PARAMETERS_COLLECTION).deleteMany({});
+  const suggestionsResult = await db.collection(SUGGESTIONS_COLLECTION).deleteMany({});
+  console.log(`[0/3] Limpeza completa: print_parameters=${printResult.deletedCount}, suggestions=${suggestionsResult.deletedCount}`);
+}
+
 async function migrateSuggestions(db) {
   console.log('[2/3] Importando sugestoes...');
 
@@ -154,6 +160,7 @@ async function migrateFinalData() {
   const db = client.db(DB_NAME);
 
   try {
+    await clearCollections(db);
     await migratePrintParameters(db);
     await migrateSuggestions(db);
     console.log('[3/3] Migracao concluida com sucesso.');

--- a/scripts/seed-mongo-atlas.js
+++ b/scripts/seed-mongo-atlas.js
@@ -100,6 +100,12 @@ async function seedSuggestions(db) {
   console.log(`ℹ️ Total atual em suggestions: ${total}`);
 }
 
+async function clearCollections(db) {
+  const printResult = await db.collection(PRINT_PARAMETERS_COLLECTION).deleteMany({});
+  const suggestionsResult = await db.collection(SUGGESTIONS_COLLECTION).deleteMany({});
+  console.log(`[0/3] Limpeza completa: print_parameters=${printResult.deletedCount}, suggestions=${suggestionsResult.deletedCount}`);
+}
+
 async function runSeed() {
   if (!MONGODB_URI) {
     throw new Error('Defina a variavel MONGODB_URI antes de rodar o seed.');
@@ -114,6 +120,7 @@ async function runSeed() {
   const db = client.db(DB_NAME);
 
   try {
+    await clearCollections(db);
     await seedPrintParameters(db);
     await seedSuggestions(db);
     console.log('[3/3] Seed concluido com sucesso.');


### PR DESCRIPTION
### Motivation
- Prevent incorrect mapping between base layers and exposure values when importing print parameters from Trio/HTML exports. 
- Ensure resin name is detected from table/header text so rows are assigned the correct resin (avoid `undefined` resin names). 
- Make testimonials visible on the landing page on all viewports by overriding hiding rules. 
- Avoid mixing old and new data when seeding/migrating MongoDB by clearing collections before import. 

### Description
- Improved HTML import parsing by adding `extract_resin_from_title`, `normalize_resin_name` and `enforce_column_positions`, and using the normalized resin title when building profiles in `scripts/import_print_params_from_html.py`. 
- Enforced column positions to reduce column-shift errors that could swap `baseLayers` and `exposureTimeS`. 
- Added CSS rules in `public/index.html` to force `.secao-familia { display: flex !important; visibility: visible !important; }`. 
- Added `clearCollections(db)` and calls to it in both `scripts/migrate-final-data.js` and `scripts/seed-mongo-atlas.js` so `print_parameters` and `suggestions` are deleted before importing new data. 

### Testing
- Ran `python scripts/import_print_params_from_html.py /tmp/parametros.html /tmp/resins_from_html.json` which generated `/tmp/resins_from_html.json` and RAG/db JSON files successfully. 
- Compared generated profiles against existing `data/resins_extracted.json` and found `missing=0`, `extra=0`, and `changed=0`, confirming parsing produced consistent profiles. 
- Executed quick Python checks that reported a couple of profiles with `baseLayers < 3` (logged for review) and verified exposure/base value distributions. 
- Started a local static server and used Playwright to capture `public/index.html` confirming the testimonial section renders with the new `secao-familia` styles; all steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a28eba20c8333b852c8079011f535)