### PR TITLE
Use environment variables for admin secret and API base

### DIFF
--- a/RELATORIO_TESTES.md
+++ b/RELATORIO_TESTES.md
@@ -191,8 +191,8 @@ open admin-panel-test.html
 ### **3. Verificações de Produção**
 ```bash
 # Verificar endpoints
-curl "http://localhost:3001/suggestions?auth=quanton3d_admin_secret"
-curl "http://localhost:3001/rag-status?auth=quanton3d_admin_secret"
+curl "http://localhost:3001/suggestions?auth=${ADMIN_SECRET}"
+curl "http://localhost:3001/rag-status?auth=${ADMIN_SECRET}"
 
 # Verificar logs
 tail -f rag-operations.log
@@ -210,7 +210,7 @@ tail -f operations.log
 ## ⚠️ **PONTOS DE ATENÇÃO**
 
 ### **Críticos:**
-- 🔒 **Autenticação:** Todos endpoints protegidos com `quanton3d_admin_secret`
+- 🔒 **Autenticação:** Todos endpoints protegidos com `ADMIN_SECRET` via variável de ambiente
 - 💾 **Backups:** Sistema cria backups automáticos antes de mudanças
 - 📝 **Logs:** Monitorar `rag-operations.log` e `operations.log`
 

--- a/admin-panel-test.html
+++ b/admin-panel-test.html
@@ -178,8 +178,14 @@
         </div>
     </div>
 
-    <script>
-        const API_BASE = 'https://quanton3d-bot.onrender.com';
+    <script type="module">
+        const resolveApiBase = () => {
+            const viteApi = (typeof import.meta !== 'undefined' && import.meta.env) ? import.meta.env.VITE_API_URL : undefined;
+            const windowApi = window.VITE_API_URL || window.env?.VITE_API_URL;
+            return viteApi || windowApi || 'https://quanton3d-bot.onrender.com';
+        };
+
+        const API_BASE = resolveApiBase();
         const AUTH_TOKEN_KEY = 'quanton3d_admin_token';
         let authToken = localStorage.getItem(AUTH_TOKEN_KEY) || '';
         const loginStatus = document.getElementById('login-status');

--- a/admin/security.js
+++ b/admin/security.js
@@ -26,11 +26,11 @@ function verifySSE(req, res, next, jwtSecret){
   catch { return res.status(401).end(); }
 }
 
-function attachAdminSecurity(app){
-  const ADMIN_SECRET = process.env.ADMIN_SECRET;
-  const ADMIN_JWT_SECRET = process.env.ADMIN_JWT_SECRET;
-  const ADMIN_USERNAME = process.env.ADMIN_USERNAME || "admin";
-  const ALLOWED = allowListFromEnv(process.env.CORS_ORIGIN);
+function attachAdminSecurity(app, config = {}){
+  const ADMIN_SECRET = config.adminSecret ?? process.env.ADMIN_SECRET;
+  const ADMIN_JWT_SECRET = config.adminJwtSecret ?? process.env.ADMIN_JWT_SECRET;
+  const ADMIN_USERNAME = config.adminUsername ?? process.env.ADMIN_USERNAME ?? "admin";
+  const ALLOWED = allowListFromEnv(config.allowedOrigins ?? process.env.CORS_ORIGIN);
 
   if (!ADMIN_SECRET || !ADMIN_JWT_SECRET) {
     console.warn("[admin] Faltam ADMIN_SECRET/ADMIN_JWT_SECRET; rotas admin não foram ativadas.");

--- a/server.js
+++ b/server.js
@@ -27,7 +27,14 @@ app.use(express.json({ limit: '50mb' }));
 app.use(express.static(publicDir));
 app.use('/public', express.static(publicDir));
 
-attachAdminSecurity(app);
+const adminSecurityOptions = {
+  adminSecret: process.env.ADMIN_SECRET,
+  adminJwtSecret: process.env.ADMIN_JWT_SECRET,
+  adminUsername: process.env.ADMIN_USERNAME,
+  allowedOrigins: process.env.CORS_ORIGIN
+};
+
+attachAdminSecurity(app, adminSecurityOptions);
 
 // --- ROTAS VITAIS (CORREÇÃO DO ERRO 'CANNOT GET') ---
 


### PR DESCRIPTION
## Summary
- pass admin secret, JWT secret, username, and allowed origins into admin security via environment-driven configuration
- update the admin test panel to honor VITE_API_URL or window-provided API base instead of a fixed backend URL
- remove hardcoded admin secret references from the test report in favor of the ADMIN_SECRET environment variable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f4cd869608333b52dce69201f3e12)