### PR TITLE
Restrict CORS to approved domains

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,21 @@ const rootDir = __dirname;
 
 const app = express();
 app.set('trust proxy', 1);
-app.use(cors());
+const allowedOrigins = [
+  "https://quanton3dia.onrender.com",
+  "https://axtonronei.online"
+];
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      return callback(null, true);
+    }
+    return callback(new Error("Not allowed by CORS"));
+  }
+};
+
+app.use(cors(corsOptions));
 app.use(express.json({ limit: '50mb' }));
 app.use(express.static(publicDir));
 app.use('/public', express.static(publicDir));


### PR DESCRIPTION
## Summary
- replace the open CORS middleware configuration with a restricted whitelist for the official domains
- add explicit CORS options to block requests from unauthorized origins

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f50550e1c8333bbde392c6893fa90)