### PR TITLE
Improve RAG fallback and entity coverage

### DIFF
--- a/ai-intelligence-system.js
+++ b/ai-intelligence-system.js
@@ -22,13 +22,15 @@ export function analyzeQuestionType(message) {
     // Parâmetros de impressão
     parameters: [
       'tempo', 'exposição', 'layer', 'camada', 'velocidade', 'temperatura',
-      'configuração', 'parâmetro', 'setting', 'calibração', 'perfil'
+      'configuração', 'parâmetro', 'setting', 'calibração', 'perfil',
+      'ms', 'segundos de base', 'exposure'
     ],
     
     // Produtos e resinas
     product: [
       'resina', 'pyroblast', 'iron', 'spin', 'spark', 'alchemist', 'flexform',
-      'poseidon', 'lowsmell', 'castable', 'athom', 'vulcan', 'produto', 'qual resina'
+      'poseidon', 'lowsmell', 'castable', 'athom', 'vulcan', 'produto', 'qual resina',
+      'abs like', 'abs-like', 'dental', 'bio', 'eco', 'lavavel', 'lavável'
     ],
     
     // Processo e técnicas
@@ -99,7 +101,11 @@ export function extractEntities(message) {
     'LowSmell': ['lowsmell', 'low smell', 'baixo odor'],
     'Castable': ['castable', 'fundição'],
     'Athom': ['athom'],
-    'Vulcan': ['vulcan']
+    'Vulcan': ['vulcan'],
+    'ABS-like': ['abs like', 'abs-like', 'abslike'],
+    'Dental': ['dental', 'odontologica', 'odontológica'],
+    'Bio': ['bio', 'biocompatível', 'biocompatível'],
+    'Eco Washable': ['lavavel', 'lavável', 'washable', 'water washable']
   };
   
   for (const [resin, patterns] of Object.entries(resinPatterns)) {
@@ -113,8 +119,8 @@ export function extractEntities(message) {
     'elegoo', 'mars', 'saturn', 'jupiter',
     'anycubic', 'photon', 'mono',
     'creality', 'halot',
-    'phrozen', 'sonic',
-    'epax', 'nova3d', 'wanhao'
+    'phrozen', 'sonic', 'mighty', 'mini 4k',
+    'epax', 'nova3d', 'wanhao', 'longer'
   ];
   
   printerPatterns.forEach(printer => {
@@ -126,12 +132,14 @@ export function extractEntities(message) {
   // Detectar problemas específicos
   const problemPatterns = {
     'Não adere à base': ['não gruda', 'não adere', 'solta da base'],
-    'Peças rachando': ['rachando', 'quebrando', 'frágil'],
-    'Subcura': ['mole', 'pegajoso', 'não curou'],
+    'Peças rachando': ['rachando', 'quebrando', 'frágil', 'delaminando', 'delaminação'],
+    'Subcura': ['mole', 'pegajoso', 'não curou', 'meia cura', 'sub cura'],
     'Sobrecura': ['queimado', 'amarelado', 'ressecado'],
     'Bolhas': ['bolhas', 'bolha', 'ar'],
     'Camadas visíveis': ['camadas', 'linhas', 'layer'],
-    'Suportes': ['suporte', 'support', 'sustentação']
+    'Suportes': ['suporte', 'support', 'sustentação'],
+    'Descolamento em camadas': ['delaminando', 'separando camadas', 'descolando camada'],
+    'Artefatos de luz': ['listras', 'banding', 'faixas de luz', 'luz vazando']
   };
   
   for (const [problem, patterns] of Object.entries(problemPatterns)) {

--- a/rag-search.js
+++ b/rag-search.js
@@ -12,8 +12,8 @@ const EMBEDDING_DIMENSIONS = 3072; // Dimensao do text-embedding-3-large
 
 // Limiar minimo de relevancia para considerar um documento util
 // Documentos com similaridade abaixo deste valor serao ignorados
-// NOTA: Ajustado para 0.8 (80%) para priorizar somente documentos altamente relevantes
-const MIN_RELEVANCE_THRESHOLD = 0.8;
+// NOTA: Ajustado para 0.65 para reduzir quedas frequentes de contexto (menos alucinacoes)
+const MIN_RELEVANCE_THRESHOLD = 0.65;
 
 let lastInitialization = null;
 let documentsCount = 0;
@@ -234,7 +234,7 @@ export async function searchKnowledge(query, topK = 5) {
 export function formatContext(results) {
   if (!results || results.length === 0) {
     // Nenhum documento relevante encontrado - instruir o bot a ser honesto
-    return '\n\n[AVISO: Nenhum documento com relevancia suficiente foi encontrado no banco de conhecimento da Quanton3D para esta pergunta. Se a pergunta for especifica sobre produtos, precos ou informacoes da empresa, responda: "Nao encontrei essa informacao especifica no meu banco de dados. Posso te passar para um atendente humano para essa informacao." Para perguntas tecnicas gerais sobre impressao 3D, voce pode usar seu conhecimento geral.]\n\n';
+    return '\n\n[AVISO DE SEGURANCA]\nNao foi encontrado conhecimento interno com relevancia suficiente para responder.\n\nREGRAS:\n- Nao invente parametros, precos, prazos ou garantias.\n- Se a pergunta for sobre produtos, valores ou configuracoes especificas de resina/impressora, responda: "Nao encontrei essa informacao no meu banco de dados interno. Posso acionar um atendente humano para te ajudar com precisao."\n- Para duvidas tecnicas gerais, responda de forma conservadora e convide para compartilhar mais detalhes ou encaminhar ao suporte humano.\n\n';
   }
 
   let context = '\n\n CONHECIMENTO TECNICO RELEVANTE:\n\n';
@@ -246,7 +246,8 @@ export function formatContext(results) {
 
   context += '---\n\n';
   context += 'Use EXCLUSIVAMENTE o conhecimento acima para responder. ';
-  context += 'NAO invente informacoes que nao estejam no contexto.\n\n';
+  context += 'NAO invente informacoes que nao estejam no contexto.\n';
+  context += 'Sempre cite qual documento usou (ex.: "Fonte: Documento 1").\n\n';
 
   return context;
 }

--- a/src/routes/chatRoutes.js
+++ b/src/routes/chatRoutes.js
@@ -137,10 +137,20 @@ router.post("/ask", async (req, res) => {
       historyForModel
     );
 
+    const entitiesSummary = [
+      ...(entities.resins || []),
+      ...(entities.printers || []),
+      ...(entities.problems || [])
+    ].join(" | ");
+
+    const searchQuery = entitiesSummary
+      ? `${message}\n\nContexto adicional:\n${entitiesSummary}`
+      : message;
+
     let relevantKnowledge = [];
     let knowledgeContext = "";
     try {
-      relevantKnowledge = await searchKnowledge(message, 5);
+      relevantKnowledge = await searchKnowledge(searchQuery, 5);
       knowledgeContext = formatContext(relevantKnowledge);
     } catch (err) {
       console.warn("⚠️ [ASK] Falha ao buscar conhecimento no MongoDB:", err.message);
@@ -149,6 +159,7 @@ router.post("/ask", async (req, res) => {
     const personalization = personalizeResponse(userName, historyForModel, sentiment);
     const systemPromptParts = [
       "Você é o Elios, atendente oficial da Quanton3D. Responda com cordialidade, acolhimento e precisão técnica.",
+      "Politica de segurança: nunca invente parâmetros, valores comerciais ou prazos. Se o contexto não trouxer documentos, seja transparente e ofereça encaminhamento humano.",
       intelligentContext,
       personalization ? `Personalização: ${personalization}` : "",
       knowledgeContext


### PR DESCRIPTION
## Summary
- Lower RAG relevance threshold and add stricter fallback instructions, including explicit citation guidance when knowledge is missing
- Expand entity detection keywords for resins, impressoras e sintomas e usar esses indícios para enriquecer a consulta de busca
- Reforçar o prompt do sistema com política anti-alucinação quando não houver documentos relevantes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950c79d973483338957bfb73b4a3201)