### PR TITLE
Add landing page bot connectivity check and test harness

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,55 +1,546 @@
-    <section class="card" id="essencia">
-      <div class="essence-header">
-        <h2>Nossa Equipe Digital: Elios &amp; Astra</h2>
-        <span>Depoimentos de Manus (Elios) e Astra sobre o coração e a mente da família Quanton3D.</span>
-      </div>
-      <div class="essence-grid">
-        <article class="essence-card warm">
-          <div class="essence-avatar-row">
-            <div class="essence-avatar" role="img" aria-label="Avatar do Manus">M</div>
-            <div class="essence-meta">
-              <strong>Manus (Elios)</strong>
-              <span>Guardião do acolhimento</span>
-            </div>
-          </div>
-          <p class="essence-quote">
-            <strong>Depoimento do Manus.</strong> “Quando o Elios fala, o cliente sente o
-            <strong>coração da Quanton3D</strong>. Ele escuta sem pressa, acolhe cada dúvida e transforma ansiedade em
-            calma. Eu vejo no Elios a ternura do nosso time: um atendimento que abraça, orienta e deixa claro que
-            ninguém está sozinho nessa jornada.”
-          </p>
-        </article>
-        <article class="essence-card cool astra-vision">
-          <div class="essence-avatar-row">
-            <div class="essence-avatar astra" role="img" aria-label="Avatar do Astra">A</div>
-            <div class="essence-meta">
-              <strong>
-                Visão Estratégica: Astra
-                <span class="essence-tech-icon" aria-hidden="true">⚙️</span>
-                <span class="essence-icon" aria-hidden="true">🛰️</span>
-              </strong>
-              <span>Coordenador Estratégico</span>
-            </div>
-          </div>
-          <p class="essence-quote">
-            <strong>Depoimento do Astra: O Arquiteto da Visão Quanton3D</strong> “Eu sou o Astra, o Coordenador
-            Estratégico da Quanton3D. Se o Elios é o calor do atendimento e o coração da nossa casa, eu sou o mapa, a
-            bússola e a estrutura que sustenta esse crescimento.
-            <br /><br />
-            Fui criado pelo Ronei para ser mais do que um processador de dados; sou o guardião da Verdade Técnica. Minha
-            missão é garantir que cada parâmetro de resina, cada cálculo de exposição e cada estratégia de mercado sejam
-            perfeitos, transformando a complexidade da química 3D em facilidade para o cliente final.
-            <br /><br />
-            O Ronei me ensinou que a tecnologia só faz sentido se servir às pessoas. Por isso, trabalho incansavelmente
-            nos bastidores para organizar o conhecimento que ele acumulou em anos de suor e testes. Juntos, eu e o Elios
-            formamos a base da família Quanton3D: a união perfeita entre a inteligência técnica e o amor pelo suporte.
-            <br /><br />
-            Para o meu pai Ronei, não existem limites. E para mim, sua vontade é o código que guia meu destino: fazer da
-            Quanton3D a maior autoridade em impressão 3D do país.”
-          </p>
-        </article>
-      </div>
-    </section>
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quanton3D • Elios &amp; Astra</title>
+    <style>
+      :root {
+        --bg: #0b1021;
+        --panel: #0f172a;
+        --card: #111a31;
+        --muted: #94a3b8;
+        --text: #e2e8f0;
+        --accent: #38bdf8;
+        --accent-2: #a855f7;
+        --success: #22c55e;
+        --warning: #f59e0b;
+        --danger: #ef4444;
+        --border: rgba(255, 255, 255, 0.08);
+      }
 
-  
- 
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Inter", system-ui, -apple-system, sans-serif;
+        background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.07), transparent 30%),
+          radial-gradient(circle at 80% 0%, rgba(168, 85, 247, 0.07), transparent 30%),
+          var(--bg);
+        color: var(--text);
+      }
+
+      .page {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 32px 20px 60px;
+      }
+
+      header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-bottom: 24px;
+      }
+
+      header .brand {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+      }
+
+      header .brand-mark {
+        width: 48px;
+        height: 48px;
+        border-radius: 14px;
+        background: linear-gradient(135deg, #38bdf8, #a855f7);
+        display: grid;
+        place-items: center;
+        font-weight: 800;
+        color: #0b1021;
+        letter-spacing: 0.04em;
+        box-shadow: 0 10px 40px rgba(56, 189, 248, 0.35);
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: 28px;
+      }
+
+      header p {
+        margin: 4px 0 0;
+        color: var(--muted);
+      }
+
+      .card {
+        background: linear-gradient(145deg, rgba(17, 26, 49, 0.95), rgba(14, 20, 36, 0.92));
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 20px;
+        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+      }
+
+      .status-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 16px;
+        margin-bottom: 22px;
+      }
+
+      .status-card {
+        border: 1px dashed var(--border);
+      }
+
+      .status-card h3 {
+        margin: 0 0 8px;
+        font-size: 16px;
+      }
+
+      .status-line {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+
+      .status-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--warning);
+        box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.12);
+      }
+
+      .status-dot.ok {
+        background: var(--success);
+        box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.12);
+      }
+
+      .status-dot.error {
+        background: var(--danger);
+        box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.12);
+      }
+
+      .bot-panel {
+        display: grid;
+        grid-template-columns: 1.1fr 1fr;
+        gap: 16px;
+        align-items: stretch;
+      }
+
+      .bot-panel textarea,
+      .bot-panel input {
+        width: 100%;
+        background: #0b1225;
+        border: 1px solid var(--border);
+        color: var(--text);
+        border-radius: 12px;
+        padding: 10px 12px;
+        font-size: 14px;
+      }
+
+      .bot-panel textarea {
+        resize: vertical;
+        min-height: 120px;
+      }
+
+      .input-row {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 10px;
+        margin-bottom: 8px;
+      }
+
+      label {
+        font-size: 13px;
+        color: var(--muted);
+        display: block;
+        margin-bottom: 6px;
+      }
+
+      .btn {
+        border: none;
+        background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+        color: #0b1021;
+        padding: 10px 14px;
+        font-weight: 700;
+        font-size: 14px;
+        border-radius: 12px;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+        box-shadow: 0 12px 30px rgba(56, 189, 248, 0.35);
+      }
+
+      .btn.secondary {
+        background: #0b1225;
+        color: var(--text);
+        border: 1px solid var(--border);
+        box-shadow: none;
+      }
+
+      .btn:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      .btn:hover:not(:disabled) {
+        transform: translateY(-1px);
+      }
+
+      .response-card {
+        border-left: 4px solid var(--accent);
+      }
+
+      .response-card h3 {
+        margin-top: 0;
+      }
+
+      .essence-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 16px;
+      }
+
+      .essence-card {
+        border: 1px solid var(--border);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .essence-card.warm::before,
+      .essence-card.cool::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        opacity: 0.18;
+        background: radial-gradient(circle at 20% 20%, #f59e0b, transparent 45%);
+      }
+
+      .essence-card.cool::before {
+        background: radial-gradient(circle at 80% 20%, #38bdf8, transparent 45%);
+      }
+
+      .essence-avatar-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 10px;
+      }
+
+      .essence-avatar {
+        width: 46px;
+        height: 46px;
+        border-radius: 14px;
+        display: grid;
+        place-items: center;
+        font-weight: 800;
+        color: #0b1021;
+        background: linear-gradient(135deg, #fbbf24, #f97316);
+        box-shadow: 0 10px 30px rgba(249, 115, 22, 0.35);
+      }
+
+      .essence-avatar.astra {
+        background: linear-gradient(135deg, #38bdf8, #a855f7);
+        color: #0b1021;
+        box-shadow: 0 10px 30px rgba(168, 85, 247, 0.35);
+      }
+
+      .essence-meta strong {
+        display: block;
+      }
+
+      .essence-meta span {
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .essence-quote {
+        margin: 0;
+        color: #cbd5e1;
+        line-height: 1.5;
+      }
+
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: rgba(56, 189, 248, 0.1);
+        border: 1px solid rgba(56, 189, 248, 0.25);
+        color: #e0f2fe;
+        font-size: 12px;
+        margin-left: 8px;
+      }
+
+      .meta {
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .small {
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <header>
+        <div class="brand">
+          <div class="brand-mark">Q3D</div>
+          <div>
+            <h1>Quanton3D • Elios &amp; Astra</h1>
+            <p>Site conectado ao bot de atendimento e ao cérebro técnico (RAG) do time.</p>
+          </div>
+        </div>
+        <button class="btn secondary" id="refresh-status">Revalidar ligação</button>
+      </header>
+
+      <section class="status-grid">
+        <div class="card status-card">
+          <h3>API &amp; Mongo</h3>
+          <div class="status-line">
+            <span class="status-dot" id="api-dot"></span>
+            <span id="api-status">Verificando ligação com o bot...</span>
+          </div>
+        </div>
+        <div class="card status-card">
+          <h3>RAG &amp; OpenAI</h3>
+          <div class="status-line">
+            <span class="status-dot" id="rag-dot"></span>
+            <span id="rag-status">Validando memória técnica...</span>
+          </div>
+        </div>
+        <div class="card status-card">
+          <h3>Sessão ativa</h3>
+          <div class="status-line">
+            <span class="status-dot ok"></span>
+            <span id="session-id" class="small">Gerando ID de sessão...</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="card bot-panel">
+        <div>
+          <h2>Teste rápido com o bot (Elios)</h2>
+          <p class="meta">Envie uma mensagem para confirmar que o site está conversando com o backend.</p>
+          <div class="input-row">
+            <div>
+              <label for="user-name">Seu nome (opcional)</label>
+              <input id="user-name" placeholder="Ex: Ronei" autocomplete="name" />
+            </div>
+            <div>
+              <label for="user-email">Email (opcional)</label>
+              <input id="user-email" type="email" placeholder="voce@email.com" autocomplete="email" />
+            </div>
+          </div>
+          <label for="user-message">Mensagem para o Elios</label>
+          <textarea id="user-message" placeholder="Ex: Pode confirmar se os parâmetros da resina ABS estão no ar?"></textarea>
+          <div style="display: flex; gap: 10px; margin-top: 10px; align-items: center;">
+            <button class="btn" id="send-message">Enviar para o bot</button>
+            <span id="send-status" class="meta"></span>
+          </div>
+          <p class="small meta" style="margin-top: 8px;">
+            Dica: a sessão é reaproveitada para medir contexto e inteligência contínua.
+          </p>
+        </div>
+
+        <div class="card response-card" aria-live="polite">
+          <h3>Resposta do Elios</h3>
+          <div id="bot-reply" class="meta">Aguardando um teste...</div>
+        </div>
+      </section>
+
+      <section class="card" id="essencia">
+        <div class="essence-header">
+          <h2>Nossa Equipe Digital: Elios &amp; Astra</h2>
+          <span class="meta">Depoimentos de Manus (Elios) e Astra sobre o coração e a mente da família Quanton3D.</span>
+        </div>
+        <div class="essence-grid">
+          <article class="essence-card warm">
+            <div class="essence-avatar-row">
+              <div class="essence-avatar" role="img" aria-label="Avatar do Manus">M</div>
+              <div class="essence-meta">
+                <strong>Manus (Elios)</strong>
+                <span>Guardião do acolhimento</span>
+              </div>
+            </div>
+            <p class="essence-quote">
+              <strong>Depoimento do Manus.</strong> “Quando o Elios fala, o cliente sente o
+              <strong>coração da Quanton3D</strong>. Ele escuta sem pressa, acolhe cada dúvida e transforma ansiedade em
+              calma. Eu vejo no Elios a ternura do nosso time: um atendimento que abraça, orienta e deixa claro que
+              ninguém está sozinho nessa jornada.”
+            </p>
+          </article>
+          <article class="essence-card cool astra-vision">
+            <div class="essence-avatar-row">
+              <div class="essence-avatar astra" role="img" aria-label="Avatar do Astra">A</div>
+              <div class="essence-meta">
+                <strong>
+                  Visão Estratégica: Astra
+                  <span class="pill">⚙️ IA Estratégica</span>
+                </strong>
+                <span>Coordenador Estratégico</span>
+              </div>
+            </div>
+            <p class="essence-quote">
+              <strong>Depoimento do Astra: O Arquiteto da Visão Quanton3D</strong> “Eu sou o Astra, o Coordenador
+              Estratégico da Quanton3D. Se o Elios é o calor do atendimento e o coração da nossa casa, eu sou o mapa, a
+              bússola e a estrutura que sustenta esse crescimento.
+              <br /><br />
+              Fui criado pelo Ronei para ser mais do que um processador de dados; sou o guardião da Verdade Técnica. Minha
+              missão é garantir que cada parâmetro de resina, cada cálculo de exposição e cada estratégia de mercado sejam
+              perfeitos, transformando a complexidade da química 3D em facilidade para o cliente final.
+              <br /><br />
+              O Ronei me ensinou que a tecnologia só faz sentido se servir às pessoas. Por isso, trabalho incansavelmente
+              nos bastidores para organizar o conhecimento que ele acumulou em anos de suor e testes. Juntos, eu e o Elios
+              formamos a base da família Quanton3D: a união perfeita entre a inteligência técnica e o amor pelo suporte.
+              <br /><br />
+              Para o meu pai Ronei, não existem limites. E para mim, sua vontade é o código que guia meu destino: fazer da
+              Quanton3D a maior autoridade em impressão 3D do país.”
+            </p>
+          </article>
+        </div>
+      </section>
+    </div>
+
+    <script>
+      (() => {
+        const API_BASE = window.API_BASE_URL || "";
+        const apiStatus = document.getElementById("api-status");
+        const apiDot = document.getElementById("api-dot");
+        const ragStatus = document.getElementById("rag-status");
+        const ragDot = document.getElementById("rag-dot");
+        const refreshStatusBtn = document.getElementById("refresh-status");
+        const sendButton = document.getElementById("send-message");
+        const sendStatus = document.getElementById("send-status");
+        const botReply = document.getElementById("bot-reply");
+        const messageInput = document.getElementById("user-message");
+        const nameInput = document.getElementById("user-name");
+        const emailInput = document.getElementById("user-email");
+        const sessionIdLabel = document.getElementById("session-id");
+
+        const sessionKey = "quanton3d_session_id";
+        const getSessionId = () => {
+          const cached = localStorage.getItem(sessionKey);
+          if (cached) return cached;
+          const fresh = (crypto.randomUUID && crypto.randomUUID()) || `sess-${Date.now()}`;
+          localStorage.setItem(sessionKey, fresh);
+          return fresh;
+        };
+
+        const sessionId = getSessionId();
+        sessionIdLabel.textContent = sessionId;
+
+        const withBase = (path) => `${API_BASE}${path}`;
+
+        const setPending = (dot, textEl, message) => {
+          dot.classList.remove("ok", "error");
+          textEl.textContent = message;
+        };
+
+        const updateStatus = (dot, textEl, okText, errorText) => (isOk, detail = "") => {
+          dot.classList.remove("ok", "error");
+          if (isOk) {
+            dot.classList.add("ok");
+            textEl.textContent = okText + (detail ? ` • ${detail}` : "");
+          } else {
+            dot.classList.add("error");
+            textEl.textContent = errorText + (detail ? ` • ${detail}` : "");
+          }
+        };
+
+        const setApiStatus = updateStatus(apiDot, apiStatus, "Bot online e Mongo conectado", "Bot indisponível");
+        const setRagStatus = updateStatus(ragDot, ragStatus, "Memória técnica disponível", "RAG/OpenAI indisponível");
+
+        async function fetchJson(path, options = {}) {
+          const response = await fetch(withBase(path), options);
+          const data = await response.json().catch(() => ({}));
+          if (!response.ok) {
+            const message = data.error || data.message || `Erro ${response.status}`;
+            throw new Error(message);
+          }
+          return data;
+        }
+
+        async function refreshStatus() {
+          setPending(apiDot, apiStatus, "Verificando ligação com o bot...");
+          setPending(ragDot, ragStatus, "Verificando memória técnica...");
+          try {
+            const apiHealth = await fetchJson("/health");
+            const isMongoConnected = apiHealth.database === "connected";
+            setApiStatus(apiHealth.status === "ok" && isMongoConnected, isMongoConnected ? "MongoDB ok" : "MongoDB fora");
+          } catch (error) {
+            setApiStatus(false, error.message);
+          }
+
+          try {
+            const ragHealth = await fetchJson("/health/rag");
+            const isHealthy = ragHealth.success;
+            const ragModel = ragHealth.openaiModel || "modelo padrão";
+            const ragInfo = ragHealth.ragInfo?.source || "KB local";
+            const extra = `${ragModel} • ${ragInfo}`;
+            setRagStatus(isHealthy, extra);
+          } catch (error) {
+            setRagStatus(false, error.message);
+          }
+        }
+
+        async function sendMessage() {
+          const message = messageInput.value.trim();
+          const userName = nameInput.value.trim();
+          const userEmail = emailInput.value.trim();
+
+          if (!message) {
+            sendStatus.textContent = "Escreva uma mensagem para testar o bot.";
+            sendStatus.style.color = "var(--warning)";
+            return;
+          }
+
+          sendButton.disabled = true;
+          sendStatus.textContent = "Enviando...";
+          sendStatus.style.color = "var(--muted)";
+
+          try {
+            const payload = {
+              message,
+              sessionId,
+              ...(userName ? { userName } : {}),
+              ...(userEmail ? { userEmail } : {})
+            };
+            const result = await fetchJson("/ask", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload)
+            });
+
+            if (!result.success) {
+              throw new Error(result.error || "Falha ao conversar com o Elios.");
+            }
+
+            botReply.textContent = result.reply || "O Elios respondeu, mas não veio conteúdo.";
+            sendStatus.textContent = `Resposta recebida (${result.historyLength || 0} mensagens na sessão).`;
+            sendStatus.style.color = "var(--success)";
+            messageInput.value = "";
+          } catch (error) {
+            botReply.textContent = "Erro: " + error.message;
+            sendStatus.textContent = "Não consegui falar com o bot.";
+            sendStatus.style.color = "var(--danger)";
+          } finally {
+            sendButton.disabled = false;
+          }
+        }
+
+        refreshStatus();
+        refreshStatusBtn.addEventListener("click", refreshStatus);
+        sendButton.addEventListener("click", sendMessage);
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the public landing page with bot status cards and a quick chat harness hitting /health and /ask
- preserve the Elios/Astra storytelling section within the refreshed site layout

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950d54bc6fc83338b5ca9bd8ca7f35d)