### PR TITLE
Improve bot route wiring and fallback handling

### DIFF
--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -1,7 +1,9 @@
 // Configurações
+const API_BASE = (window.API_BASE_URL || window.location.origin || "").replace(/\/$/, "");
+
 const CONFIG = {
-  API_URL: 'https://quanton3d-bot-v2.onrender.com/api/chat',
-  HEALTH_URL: 'https://quanton3d-bot-v2.onrender.com/health',
+  API_URL: `${API_BASE}/api/chat`,
+  HEALTH_URL: `${API_BASE}/health`,
   MAX_RETRIES: 3,
   RETRY_DELAY: 2000
 };


### PR DESCRIPTION
## Summary
- add health and rag endpoints while bootstrapping Mongo/RAG initialization
- mount chat and admin routes into the main server alongside existing static assets
- return fallback replies when AI or database are unavailable and align the public chat client with local API paths

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69533cf6f9888333b8c16d450d970b00)