### PR TITLE
Add concise vision prompt and expose print parameters API

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -412,7 +412,7 @@
 
     <script>
       (() => {
-        const API_BASE = window.API_BASE_URL || "";
+        const API_BASE = (window.API_BASE_URL || "https://quanton3d-bot-v2.onrender.com").replace(/\/$/, "");
         const apiStatus = document.getElementById("api-status");
         const apiDot = document.getElementById("api-dot");
         const ragStatus = document.getElementById("rag-status");

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -1,5 +1,5 @@
 // Configurações
-const API_BASE = (window.API_BASE_URL || window.location.origin || "").replace(/\/$/, "");
+const API_BASE = (window.API_BASE_URL || "https://quanton3d-bot-v2.onrender.com" || window.location.origin || "").replace(/\/$/, "");
 
 const CONFIG = {
   API_URL: `${API_BASE}/api/chat`,

--- a/public/params-panel.html
+++ b/public/params-panel.html
@@ -436,6 +436,9 @@
           ["Exposição", params.exposureTimeS && `${params.exposureTimeS}s`],
           ["Base", params.baseExposureTimeS && `${params.baseExposureTimeS}s`],
           ["Cam. base", params.baseLayers && Math.round(params.baseLayers)],
+          ["Retardo UV", params.uvOffDelayS != null ? `${params.uvOffDelayS}s` : null],
+          ["Retardo UV base", params.uvOffDelayBaseS != null ? `${params.uvOffDelayBaseS}s` : null],
+          ["Descanso", params.restAfterLiftS != null ? `${params.restAfterLiftS}s` : params.restAfterRetractS != null ? `${params.restAfterRetractS}s` : null],
           ["UV", params.uvPower || null]
         ].filter(([, value]) => value);
 

--- a/server.js
+++ b/server.js
@@ -109,7 +109,7 @@ app.get('/health/metrics', (_req, res) => {
 // Delega DIRETO para a rota /ask via Express (sem hacks)
 app.post('/api/chat', async (req, res, next) => {
   try {
-    const { message, sessionId, userName, userEmail, userPhone, resin, printer } = req.body;
+    const { message, sessionId, userName, userEmail, userPhone, resin, printer, image, imageUrl } = req.body;
     
     // Validação básica
     if (!message || typeof message !== 'string' || message.trim().length === 0) {
@@ -130,7 +130,9 @@ app.post('/api/chat', async (req, res, next) => {
       userEmail: userEmail || undefined,
       userPhone: userPhone || undefined,
       resin: resin || undefined,
-      printer: printer || undefined
+      printer: printer || undefined,
+      image: image || undefined,
+      imageUrl: imageUrl || undefined
     };
     
     // ✅ Redirecionar para handler de /ask via next('route')


### PR DESCRIPTION
## Summary
- Tighten the Elios system prompt for concise, knowledge-based replies and enable GPT-4o vision content (image URL/base64) with metadata tracking
- Forward image fields through /api/chat and default frontend API base URLs to quanton3d-bot-v2 for consistent backend targeting
- Publish MongoDB-backed print parameter endpoints (/api/params/*) and surface UV delay/descanso fields in the public parameters panel

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959fd81119c8333991dd57919ae833e)