### PR TITLE
Point resin endpoints to parametros collection

### DIFF
--- a/apiClient.js
+++ b/apiClient.js
@@ -1,0 +1,75 @@
+// Cliente simples para consumir a API pública do Quanton3D Bot.
+// Não depende de variáveis do backend como MONGODB_URI, evitando expor
+// dados sensíveis no frontend.
+
+const DEFAULT_API_BASE = "https://quanton3d-bot-v2.onrender.com";
+
+const normalizeUrl = (url) => url.replace(/\/$/, "");
+
+function resolveApiBase() {
+  const viteApi =
+    typeof import.meta !== "undefined" && import.meta.env
+      ? import.meta.env.VITE_API_URL
+      : undefined;
+  const browserApi =
+    typeof window !== "undefined"
+      ? window.API_BASE_URL || window.VITE_API_URL || window.env?.VITE_API_URL
+      : undefined;
+
+  return normalizeUrl(viteApi || browserApi || DEFAULT_API_BASE);
+}
+
+const API_BASE = resolveApiBase();
+
+async function request(path, options = {}) {
+  const url = `${API_BASE}${path.startsWith("/") ? path : `/${path}`}`;
+  const config = {
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers || {})
+    },
+    ...options
+  };
+
+  const response = await fetch(url, config);
+  const data = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const error = new Error(data.error || data.message || "Erro na requisição");
+    error.status = response.status;
+    error.data = data;
+    throw error;
+  }
+
+  return data;
+}
+
+export async function fetchResins() {
+  return request("/resins");
+}
+
+export async function fetchPrinters(resinId) {
+  const query = resinId ? `?resinId=${encodeURIComponent(resinId)}` : "";
+  return request(`/api/params/printers${query}`);
+}
+
+export async function registerUser(payload) {
+  return request("/api/register-user", {
+    method: "POST",
+    body: JSON.stringify(payload || {})
+  });
+}
+
+export async function sendChatMessage(payload) {
+  return request("/api/chat", {
+    method: "POST",
+    body: JSON.stringify(payload || {})
+  });
+}
+
+export default {
+  fetchResins,
+  fetchPrinters,
+  registerUser,
+  sendChatMessage
+};

--- a/db.js
+++ b/db.js
@@ -67,9 +67,9 @@ export async function connectToMongo() {
       await db.createCollection('messages');
       console.log('[MongoDB] Colecao "messages" criada');
     }
-    if (!collectionNames.includes('print_parameters')) {
-      await db.createCollection('print_parameters');
-      console.log('[MongoDB] Colecao "print_parameters" criada');
+    if (!collectionNames.includes('parametros')) {
+      await db.createCollection('parametros');
+      console.log('[MongoDB] Colecao "parametros" criada');
     }
 
     await ensureMongoIndexes();
@@ -129,7 +129,7 @@ export function getPartnersCollection() {
 
 // Obter colecao de parametros de impressao
 export function getPrintParametersCollection() {
-  return getDb().collection('print_parameters');
+  return getDb().collection('parametros');
 }
 
 // Obter colecao de metricas de conversas

--- a/server.js
+++ b/server.js
@@ -177,7 +177,7 @@ const requireAuth = async (req, res, next) => {
   return verifyJWT(req, res, next);
 };
 
-// ✅ ROTA /resins PÚBLICA – lida diretamente do MongoDB (print_parameters)
+// ✅ ROTA /resins PÚBLICA – lida diretamente do MongoDB (parametros)
 app.get("/resins", async (_req, res) => {
   try {
     await connectToMongo();


### PR DESCRIPTION
## Summary
- switch MongoDB print parameter collection helpers to use the existing `parametros` collection
- ensure the public /resins endpoint serves data from the corrected collection
- add a frontend-safe API client helper that avoids exposing backend-only variables

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b59526e048333b3553e9f0c820415)