### PR TITLE
Fix resin data sourcing and API compatibility

### DIFF
--- a/models/schemas.js
+++ b/models/schemas.js
@@ -37,7 +37,7 @@ const ParametrosSchema = new mongoose.Schema({
   },
   createdAt: { type: Date, default: Date.now, index: true },
   updatedAt: { type: Date, default: Date.now }
-}, { collection: 'print_parameters' });
+}, { collection: 'parametros' });
 
 ParametrosSchema.index({ resin: 1, printer: 1, createdAt: -1 });
 ParametrosSchema.index({ sessionId: 1, createdAt: -1 });


### PR DESCRIPTION
## Summary
- ensure Mongo uses the `parametros` collection as the primary source and warn when only a legacy collection exists
- serve resin listings for public and admin routes directly from MongoDB instead of the local JSON fallback
- add extra `/api/api` mounting for chat and API routes to handle clients that double-prefix the base path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b6d6d5d2883339472eca92fc51e7d)