### PR TITLE
Use 'parametros' collection for resins and alias auth middleware

### DIFF
--- a/db.js
+++ b/db.js
@@ -14,7 +14,6 @@ const MONGODB_URI = process.env.MONGODB_URI;
 const DB_NAME = 'quanton3d';
 const PRIMARY_PARAMETERS_COLLECTION = 'parametros';
 const LEGACY_PARAMETERS_COLLECTION = 'print_parameters';
-const activeParametersCollectionName = PRIMARY_PARAMETERS_COLLECTION;
 const connectionOptions = {
   dbName: DB_NAME,
   serverSelectionTimeoutMS: 5000,
@@ -237,7 +236,7 @@ export function getPartnersCollection() {
 
 // Obter colecao de parametros de impressao
 export function getPrintParametersCollection() {
-  return getCollection(activeParametersCollectionName);
+  return getDb().collection('parametros');
 }
 
 // Obter colecao de metricas de conversas

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ import { attachAdminSecurity } from "./admin/security.js";
 import attachKnowledgeRoutes from "./admin/knowledge-routes.js";
 import { chatRoutes } from "./src/routes/chatRoutes.js";
 import { buildAdminRoutes } from "./src/routes/adminRoutes.js";
-import { authRoutes, verifyJWT } from "./src/routes/authRoutes.js";
+import { authRoutes, requireJWT as requireJWT_middleware } from "./src/routes/authRoutes.js";
 import { suggestionsRoutes } from "./src/routes/suggestionsRoutes.js";
 import { apiRoutes } from "./src/routes/apiRoutes.js";
 import { swaggerSpec } from "./src/docs/swagger.js";
@@ -216,7 +216,7 @@ const requireAuth = async (req, res, next) => {
     return res.status(401).json({ error: 'Token inválido' });
   }
 
-  return verifyJWT(req, res, next);
+  return requireJWT_middleware(req, res, next);
 };
 
 // ✅ ROTA /resins PÚBLICA – lida diretamente do MongoDB (parametros)


### PR DESCRIPTION
### Motivation
- Ensure the app reads resin data from the canonical MongoDB collection `parametros` (not `print_parameters`) to follow the Jan 2026 data rules.
- Avoid import name conflicts for the JWT middleware to make the simplified `requireAuth` middleware call explicit.

### Description
- Updated `db.js` to make `getPrintParametersCollection()` return `getDb().collection('parametros')` directly and removed the unused `activeParametersCollectionName` indirection.
- Aliased the auth import in `server.js` to `requireJWT as requireJWT_middleware` to avoid ambiguity with other exports.
- Changed the `requireAuth` middleware in `server.js` to call `requireJWT_middleware(req, res, next)` instead of the previous symbol.
- No behavior changes to routes wiring; `/resins` and admin resin routes continue to use the print-parameters accessor which now targets `parametros`.

### Testing
- No automated tests were executed for this PR.
- A local commit was created and files updated without runtime tests.
- Manual inspection ensures `models/schemas.js` already targets the `parametros` collection so schema and collection name are consistent.
- Recommend running the test suite and starting the server to validate runtime behavior after merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cb3d469048333a445f6ab64941027)