### PR TITLE
Use environment defaults for MongoDB and enforce MONGODB_URI

### DIFF
--- a/db.js
+++ b/db.js
@@ -2,13 +2,18 @@ import { MongoClient } from 'mongodb';
 
 // Definição da constante para evitar erros de digitação
 const PRIMARY_PARAMETERS_COLLECTION = 'parametros';
+const DEFAULT_DB_NAME = process.env.MONGODB_DB || process.env.DB_NAME || 'quanton3d';
 
 let db = null;
 
-export async function connectToMongo(mongoUri, dbName) {
+export async function connectToMongo(mongoUri = process.env.MONGODB_URI, dbName = DEFAULT_DB_NAME) {
   if (db) return db;
 
   try {
+    if (!mongoUri) {
+      throw new Error('MONGODB_URI não configurado');
+    }
+
     const client = new MongoClient(mongoUri);
 
     await client.connect();


### PR DESCRIPTION
### Motivation
- Ensure the backend uses environment variables for the MongoDB connection and a stable default database name.
- Prevent silent connection failures by surfacing a clear error when `MONGODB_URI` is not configured.
- Align connection behavior with the project expectation that `parametros` is the primary print-parameters collection.
- Make bootstrap behavior deterministic for CI/Render deployments by using env-derived defaults.

### Description
- Add `DEFAULT_DB_NAME` computed from `MONGODB_DB`, `DB_NAME`, or fallback to `'quanton3d'`.
- Change `connectToMongo` signature to default `mongoUri` to `process.env.MONGODB_URI` and `dbName` to `DEFAULT_DB_NAME`.
- Throw an explicit error when `MONGODB_URI` is missing before attempting to construct the `MongoClient`.
- Preserve existing logic that lists collections and creates the `parametros` collection if it does not exist.

### Testing
- No automated tests were run for this change.
- CI/build automated tests were not executed as part of this PR run.
- Recommend running the project's test suite in CI with `MONGODB_URI` and `DB_NAME` set to validate runtime behavior.
- No automated test failures were observed because automated tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e5e523ea88333a500b787b0a94ba9)