### PR TITLE
Atualizar diretrizes técnicas (Jan 2026)

### DIFF
--- a/DIRETRIZES_TECNICAS_2026.md
+++ b/DIRETRIZES_TECNICAS_2026.md
@@ -1,35 +1,41 @@
-# Diretrizes Técnicas Atualizadas: Projeto Quanton3D (Jan 2026)
+Diretrizes Técnicas Atualizadas: Projeto Quanton3D (Jan 2026)
 
-Documento de referência consolidado para evitar regressões e ambiguidades ao configurar ou evoluir o projeto.
+1. Visão Geral da Arquitetura
 
-## 1. Visão Geral da Arquitetura
+Frontend (quanton3dia): Site estático em React/Vite. NUNCA deve conter chaves secretas (MONGODB_URI ou OPENAI_API_KEY).
 
-- **Frontend (`quanton3dia`)**: site estático em React/Vite. **Nunca** deve conter chaves secretas (`MONGODB_URI` ou `OPENAI_API_KEY`).
-- **Backend (`quanton3d-bot-v2`)**: servidor Node.js que hospeda a API, conecta no MongoDB (database `quanton3d`) e processa a IA.
+Backend (quanton3d-bot-v2): Servidor Node.js que hospeda a API, conecta no MongoDB e processa a IA.
 
-## 2. Regras de Banco de Dados (CRÍTICO)
+2. Regras de Banco de Dados (CRÍTICO - NOVO)
 
-- **Coleção de Resinas**: os dados das 459 resinas estão armazenados na coleção do MongoDB chamada **`parametros`** (não usar `print_parameters`).
-- **Leitura de Dados**: o endpoint `/resins` (e variações administrativas) deve ler **diretamente** de `db.collection('parametros')`. Não usar fallback para arquivos JSON locais para evitar dados desatualizados.
+Coleção de Resinas: Os dados das 459 resinas estão armazenados na coleção do MongoDB chamada parametros (e NÃO print_parameters).
 
-## 3. Configurações de Build e Deploy
+Leitura de Dados: O endpoint /resins deve ler diretamente do MongoDB usando db.collection('parametros'). Não use fallback para arquivos JSON locais para evitar dados desatualizados.
 
-- **Variável CI**: sempre definir `CI=true` no Render.
-- **Dependências**: usar `pnpm install --no-frozen-lockfile`.
-- **Instalação no Render**: garantir que a variável `SKIP_INSTALL` esteja como `false` quando houver atualizações de código.
+3. Configurações de Build e Deploy
 
-## 4. Integração de API e Rotas
+Variável CI: Sempre definir CI=true no Render.
 
-- **Base URL**: o frontend usa `VITE_API_URL` apontando para `https://quanton3d-bot-v2.onrender.com/api`.
-- **Compatibilidade**: o backend deve servir rotas tanto em `/api/chat` quanto na raiz `/chat` para evitar erros de CORS ou 404.
-- **Rota de Resinas**: o frontend remove o sufixo `/api` ao chamar rotas públicas de dados (por exemplo, busca em `...onrender.com/resins`).
+Dependências: Usar pnpm install --no-frozen-lockfile.
 
-## 5. Gestão de Estado (`ChatBot.jsx`)
+Instalação no Render: Garantir que a variável SKIP_INSTALL esteja como false quando houver atualizações de código.
 
-- Manter o sistema de debounce para proteger o `localStorage`.
-- Estados obrigatórios: `selectedImage`, `error`, `suggestionText`.
+4. Integração de API e Rotas
 
-## 6. Segurança
+Base URL: O frontend usa VITE_API_URL apontando para https://quanton3d-bot-v2.onrender.com/api.
 
-- **Backend (v2)**: deve conter `MONGODB_URI` (com a flag `retryWrites=true`) e `OPENAI_API_KEY`.
-- **Frontend**: apenas `VITE_API_URL` e `VITE_ADMIN_API_TOKEN`.
+Compatibilidade: O Backend deve servir rotas tanto em /api/chat quanto na raiz /chat para evitar erros de CORS ou 404.
+
+Rota de Resinas: O Frontend remove o sufixo /api ao chamar rotas públicas de dados (ex: busca em ...onrender.com/resins).
+
+5. Gestão de Estado (ChatBot.jsx)
+
+Manter sistema de debounce para proteger o localStorage.
+
+Estados obrigatórios: selectedImage, error, suggestionText.
+
+6. Segurança
+
+Backend (v2): Deve conter MONGODB_URI (com a flag retryWrites=true) e OPENAI_API_KEY.
+
+Frontend: Apenas VITE_API_URL e VITE_ADMIN_API_TOKEN.


### PR DESCRIPTION
### Motivation
- Alinhar o documento de diretrizes com a versão consolidada de janeiro de 2026 para evitar regressões operacionais.
- Remover ambiguidades que estavam causando quedas ao buscar parâmetros de impressão (ex.: leitura de arquivos JSON locais).
- Deixar explícito o nome e uso da coleção do MongoDB para resinas (`parametros`) e forçar leitura direta do banco pela API pública.
- Reforçar regras de build/deploy e variáveis de ambiente críticas para evitar deploys incorretos.

### Description
- Atualizado o arquivo `DIRETRIZES_TECNICAS_2026.md` com instruções claras sobre arquitetura, banco, deploy, rotas e segurança.  
- Documento especifica que a coleção de resinas é `parametros` e que o endpoint `/resins` deve ler diretamente de `db.collection('parametros')` sem fallback para arquivos JSON.  
- Adicionadas recomendações de build/deploy como `CI=true`, `pnpm install --no-frozen-lockfile` e garantir `SKIP_INSTALL=false` no Render, além da base API `VITE_API_URL` e compatibilidade de rotas (`/api/*` e raiz).  
- Reforçadas exigências de segurança para ambientes: `MONGODB_URI` (com `retryWrites=true`) e `OPENAI_API_KEY`, e que o frontend não deve conter chaves secretas.

### Testing
- Nenhum teste automatizado foi executado porque a mudança é apenas documental.  
- Mudança não altera código de runtime; validação funcional será feita em deploy/CI conforme o pipeline existente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8cb0e4f08333a4a86172c15fe420)