### PR TITLE
Restore stable MongoDB/Mongoose connection and ensure collections/indexes

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,80 +1,176 @@
+// Modulo de conexao com MongoDB
+// Gerencia conexao unica com o banco de dados
+
 import { MongoClient } from 'mongodb';
+import mongoose from 'mongoose';
+import {
+  Parametros,
+  Sugestoes,
+  Conversas,
+  Metricas
+} from './models/schemas.js';
 
-// Definição da constante para evitar erros de digitação
-const PRIMARY_PARAMETERS_COLLECTION = 'parametros';
-const DEFAULT_DB_NAME = process.env.MONGODB_DB || process.env.DB_NAME || 'quanton3d';
+// URI do MongoDB (OBRIGATORIO via variavel de ambiente)
+const MONGODB_URI = process.env.MONGODB_URI;
+const DB_NAME = 'quanton3d';
 
+if (!MONGODB_URI) {
+  console.error('[MongoDB] ERRO CRITICO: Variavel de ambiente MONGODB_URI nao definida!');
+  console.error('[MongoDB] Configure MONGODB_URI no Render ou no arquivo .env');
+}
+
+let client = null;
 let db = null;
+let mongooseConnected = false;
 
-export async function connectToMongo(mongoUri = process.env.MONGODB_URI, dbName = DEFAULT_DB_NAME) {
-  if (db) return db;
-
+async function ensureMongoIndexes() {
   try {
-    if (!mongoUri) {
-      throw new Error('MONGODB_URI não configurado');
-    }
-
-    const client = new MongoClient(mongoUri);
-
-    await client.connect();
-    db = client.db(dbName);
-    console.log(`[MongoDB] Conectado ao banco: ${dbName}`);
-
-    // Lista coleções existentes
-    const collections = await db.listCollections().toArray();
-    const collectionNames = collections.map(c => c.name);
-
-    // CRIAÇÃO SEGURA DA COLEÇÃO 'parametros'
-    if (!collectionNames.includes(PRIMARY_PARAMETERS_COLLECTION)) {
-      await db.createCollection(PRIMARY_PARAMETERS_COLLECTION);
-      console.log(`[MongoDB] Colecao "${PRIMARY_PARAMETERS_COLLECTION}" criada com sucesso.`);
-    }
-
-    return db;
-  } catch (error) {
-    console.error('[MongoDB] Erro fatal na conexão:', error);
-    throw error;
+    await Parametros.createIndexes();
+    await Sugestoes.createIndexes();
+    await Conversas.createIndexes();
+    await Metricas.createIndexes();
+    console.log('[MongoDB] Indices garantidos para Parametros, Sugestoes, Conversas e Metricas');
+  } catch (err) {
+    console.warn('[MongoDB] Falha ao criar indices:', err.message);
   }
 }
 
+// Conectar ao MongoDB
+export async function connectToMongo() {
+  if (db) {
+    console.log('[MongoDB] Conexao ja estabelecida');
+    return db;
+  }
+
+  try {
+    console.log('[MongoDB] Conectando ao banco de dados...');
+    if (!mongooseConnected) {
+      await mongoose.connect(MONGODB_URI, { dbName: DB_NAME });
+      mongooseConnected = true;
+      console.log('[MongoDB] Conexao Mongoose estabelecida');
+    }
+    client = new MongoClient(MONGODB_URI);
+    await client.connect();
+    db = client.db(DB_NAME);
+    
+    // Verificar colecoes existentes
+    const collections = await db.listCollections().toArray();
+    const collectionNames = collections.map(c => c.name);
+    console.log(`[MongoDB] Conectado! Colecoes existentes: ${collectionNames.join(', ') || 'nenhuma'}`);
+    
+    // Criar colecoes se nao existirem
+    if (!collectionNames.includes('documents')) {
+      await db.createCollection('documents');
+      console.log('[MongoDB] Colecao "documents" criada');
+    }
+    if (!collectionNames.includes('messages')) {
+      await db.createCollection('messages');
+      console.log('[MongoDB] Colecao "messages" criada');
+    }
+    if (!collectionNames.includes('print_parameters')) {
+      await db.createCollection('print_parameters');
+      console.log('[MongoDB] Colecao "print_parameters" criada');
+    }
+
+    await ensureMongoIndexes();
+    
+    return db;
+  } catch (err) {
+    console.error('[MongoDB] Erro ao conectar:', err.message);
+    throw err;
+  }
+}
+// Coleção para dados de aprendizado
+export function getLearningCollection() {
+  if (!db) {
+    throw new Error('Banco de dados nao conectado');
+  }
+  return db.collection('learning');
+}
+// Obter instancia do banco de dados
 export function getDb() {
   if (!db) {
-    throw new Error('Banco de dados não inicializado. Chame connectToMongo primeiro.');
+    throw new Error('[MongoDB] Banco de dados nao conectado. Chame connectToMongo() primeiro.');
   }
   return db;
 }
 
-// --- FUNÇÕES DE ACESSO ÀS COLEÇÕES ---
-
-export function getPrintParametersCollection() {
-  return getDb().collection(PRIMARY_PARAMETERS_COLLECTION);
-}
-
+// Obter colecao de documentos (RAG)
 export function getDocumentsCollection() {
   return getDb().collection('documents');
 }
 
+// Obter colecao de mensagens (Fale Conosco)
+export function getMessagesCollection() {
+  return getDb().collection('messages');
+}
+
+// Obter colecao de galeria (Fotos de impressoes)
+export function getGalleryCollection() {
+  return getDb().collection('gallery');
+}
+
+// Obter colecao de conhecimento visual (Visual RAG)
 export function getVisualKnowledgeCollection() {
   return getDb().collection('visual_knowledge');
 }
 
-export function getConversasCollection() {
-  return getDb().collection('conversas');
+// Obter colecao de sugestoes de conhecimento
+export function getSuggestionsCollection() {
+  return getDb().collection('suggestions');
 }
 
-export function getSugestoesCollection() {
-  return getDb().collection('sugestoes');
+// Obter colecao de parceiros
+export function getPartnersCollection() {
+  return getDb().collection('partners');
 }
 
+// Obter colecao de parametros de impressao
+export function getPrintParametersCollection() {
+  return getDb().collection('print_parameters');
+}
+
+// Fechar conexao (para cleanup)
+export async function closeMongo() {
+  if (client) {
+    await client.close();
+    client = null;
+    db = null;
+    console.log('[MongoDB] Conexao fechada');
+  }
+  if (mongooseConnected) {
+    await mongoose.disconnect();
+    mongooseConnected = false;
+    console.log('[MongoDB] Conexao Mongoose fechada');
+  }
+}
+
+// Verificar status da conexao
 export function isConnected() {
-  return !!db;
+  return db !== null;
 }
 
-export function getCollection(name) {
-  return getDb().collection(name);
-}
+export default {
+  connectToMongo,
+  getDb,
+  getDocumentsCollection,
+  getMessagesCollection,
+  getGalleryCollection,
+  getVisualKnowledgeCollection,
+  getSuggestionsCollection,
+  getPartnersCollection,
+  getPrintParametersCollection,
+  Parametros,
+  Sugestoes,
+  Conversas,
+  Metricas,
+  closeMongo,
+  isConnected
+};
 
-// Essa é a parte que estava dando erro, agora está arrumada:
-export function getLearningCollection() {
-  return getDb().collection('ai_learning');
-}
+export {
+  Parametros,
+  Sugestoes,
+  Conversas,
+  Metricas
+};


### PR DESCRIPTION
### Motivation

- Restore a stable Mongoose-based DB connection because the previous driver changes caused connection failures.  
- Ensure the primary data model `Parametros` (where resins live) is handled via MongoDB and has indexes created.  
- Standardize the database name to `quanton3d` and require `MONGODB_URI` to avoid ambiguous configuration.  
- Provide safe lifecycle helpers so the server can obtain collections and shut down connections cleanly.

### Description

- Replaced the entire `db.js` with a Mongoose + native `MongoClient` implementation that connects using the `MONGODB_URI` and targets the `quanton3d` database.  
- Added `ensureMongoIndexes()` to call `createIndexes()` on `Parametros`, `Sugestoes`, `Conversas`, and `Metricas`, and create missing collections such as `documents`, `messages`, and `print_parameters` at startup.  
- Added collection accessor helpers like `getDb`, `getDocumentsCollection`, `getMessagesCollection`, `getPrintParametersCollection`, `getLearningCollection`, and `getVisualKnowledgeCollection`, plus connection utilities `connectToMongo`, `closeMongo`, and `isConnected`.  
- Improved logging and error handling during connect/index operations and exported the models `Parametros`, `Sugestoes`, `Conversas`, and `Metricas` alongside the default DB API.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1efaffc883339247ac1767f5bf20)