### PR TITLE
Remove broken schemas import from chatRoutes to fix deploy ERR_MODULE_NOT_FOUND

### DIFF
--- a/src/routes/chatRoutes.js
+++ b/src/routes/chatRoutes.js
@@ -1,6 +1,4 @@
 import express from 'express';
-// Removendo importações quebradas do db.js antigo
-import { PrintParameter } from '../models/schemas.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
### Motivation

- Fix a deploy-time `ERR_MODULE_NOT_FOUND` caused by `src/routes/chatRoutes.js` importing `../models/schemas.js` from a non-existing `src/models` path. 
- Prevent the server crash during startup when Render runs `node server.js` and cannot resolve the schema module. 
- Stabilize the chat routes so the app can boot in recovery mode while further IA functionality is restored. 

### Description

- Removed the broken import of `PrintParameter` from `../models/schemas.js` in `src/routes/chatRoutes.js` to stop module resolution failures. 
- Kept the existing `/ping` and simplified `/ask` emergency response handler to allow the server to come online without referencing missing models. 
- No other routes or model files were modified. 

### Testing

- No automated tests were executed for this change. 
- The change is limited to removing a static import and does not add new runtime behavior beyond the existing simplified `/ask` reply.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3ec292b88333867f604accd8d99b)