### PR TITLE
Reativar chat com RAG e OpenAI

### DIFF
--- a/src/routes/chatRoutes.js
+++ b/src/routes/chatRoutes.js
@@ -1,13 +1,28 @@
 import express from 'express';
+import OpenAI from 'openai';
+import { searchKnowledge, formatContext } from '../../rag-search.js';
 
 const router = express.Router();
+
+const DEFAULT_CHAT_MODEL = process.env.OPENAI_CHAT_MODEL || 'gpt-4o-mini';
+let openaiClient = null;
+
+function getOpenAIClient() {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('OPENAI_API_KEY não configurada');
+  }
+
+  if (!openaiClient) {
+    openaiClient = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  }
+
+  return openaiClient;
+}
 
 // Rota de teste simples para garantir que o bot responde
 router.get('/ping', (req, res) => {
   res.json({ status: 'ok', message: 'Chat route working' });
 });
-
-const RECOVERY_REPLY = "O sistema está reiniciando e voltará com a IA em breve. (Modo de Recuperação)";
 
 function hasImagePayload(body = {}) {
   return Boolean(
@@ -19,38 +34,98 @@ function hasImagePayload(body = {}) {
   );
 }
 
+function summarizeImagePayload(body = {}) {
+  if (body.imageUrl) {
+    return `Imagem recebida via URL: ${body.imageUrl}`;
+  }
+
+  if (body.image) {
+    return 'Imagem recebida (campo image).';
+  }
+
+  if (body.imageBase64 || body.imageData || body.attachment) {
+    return 'Imagem recebida em formato base64/anexo.';
+  }
+
+  return '';
+}
+
+async function generateResponse({ message, imageSummary }) {
+  const trimmedMessage = typeof message === 'string' ? message.trim() : '';
+  const ragResults = trimmedMessage ? await searchKnowledge(trimmedMessage) : [];
+  const ragContext = formatContext(ragResults);
+
+  const prompt = [
+    ragContext,
+    trimmedMessage
+      ? `Pergunta do cliente: ${trimmedMessage}`
+      : 'O cliente enviou uma imagem sem texto explicativo.',
+    imageSummary ? `Contexto da imagem: ${imageSummary}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+
+  const client = getOpenAIClient();
+  const completion = await client.chat.completions.create({
+    model: DEFAULT_CHAT_MODEL,
+    temperature: 0.3,
+    messages: [
+      {
+        role: 'system',
+        content: 'Você é o assistente técnico oficial da Quanton3D. Responda em português e siga o contexto fornecido.'
+      },
+      {
+        role: 'user',
+        content: prompt
+      }
+    ]
+  });
+
+  const reply = completion?.choices?.[0]?.message?.content?.trim();
+
+  return {
+    reply: reply || 'Não consegui gerar uma resposta agora. Tente novamente em instantes.',
+    documentsUsed: ragResults.length
+  };
+}
+
 async function handleChatRequest(req, res) {
   try {
     const { message, sessionId } = req.body ?? {};
-    const trimmedMessage = typeof message === "string" ? message.trim() : "";
+    const trimmedMessage = typeof message === 'string' ? message.trim() : '';
     const hasMessage = trimmedMessage.length > 0;
     const hasImage = hasImagePayload(req.body);
 
-    console.log(`[CHAT] Mensagem recebida: ${trimmedMessage || "(sem texto)"}`);
+    console.log(`[CHAT] Mensagem recebida: ${trimmedMessage || '(sem texto)'}`);
 
     if (!hasMessage && !hasImage) {
-      return res.status(400).json({ error: "Mensagem ou imagem necessária" });
+      return res.status(400).json({ error: 'Mensagem ou imagem necessária' });
     }
 
-    res.json({
-      reply: RECOVERY_REPLY,
-      sessionId: sessionId || "session-recuperacao",
-      documentsUsed: 0
+    const imageSummary = hasImage ? summarizeImagePayload(req.body) : '';
+    const response = await generateResponse({
+      message: trimmedMessage,
+      imageSummary
     });
 
+    res.json({
+      reply: response.reply,
+      sessionId: sessionId || 'session-auto',
+      documentsUsed: response.documentsUsed
+    });
   } catch (error) {
-    console.error("Erro na rota de chat:", error);
-    res.status(500).json({ error: "Erro interno no servidor." });
+    console.error('Erro na rota de chat:', error);
+    res.status(500).json({ error: 'Erro interno no servidor.' });
   }
 }
 
-// Rota PRINCIPAL /ask (Simplificada para estabilizar o sistema)
-router.post("/ask", handleChatRequest);
+// Rota PRINCIPAL /ask
+router.post('/ask', handleChatRequest);
 
 // Compatibilidade: /chat (frontend antigo)
-router.post("/chat", handleChatRequest);
+router.post('/chat', handleChatRequest);
 
 // Compatibilidade: /ask-with-image (frontend com imagem)
-router.post("/ask-with-image", handleChatRequest);
+router.post('/ask-with-image', handleChatRequest);
 
 export { router as chatRoutes };


### PR DESCRIPTION
### Motivation

- Restaurar a lógica real de chat com IA removendo a resposta fixa de "Modo de Recuperação" para voltar a gerar respostas úteis aos usuários.
- Reintegrar busca RAG e geração via OpenAI para aproveitar o conhecimento armazenado no MongoDB e melhorar a precisão técnica das respostas.
- Garantir compatibilidade com a base atual de código e `db.js` sem chamar funções inexistentes.
- Suportar entrada por texto e imagem mantendo compatibilidade com rotas antigas do frontend.

### Description

- Remove a resposta estática de recuperação e adiciona integração com OpenAI importando `OpenAI` e inicializando um cliente via `getOpenAIClient()`.
- Reintegra a busca RAG importando `searchKnowledge` e `formatContext` de `../../rag-search.js` e monta prompts com o contexto retornado.
- Adiciona helpers `summarizeImagePayload()` e `generateResponse()` para criar prompts combinando texto e resumo de imagem, e expõe `documentsUsed` com o número de resultados RAG.
- Mantém as rotas compatíveis `POST /ask`, `POST /chat` e `POST /ask-with-image` e a rota de saúde `GET /ping` sem alterar chamadas ao `db.js` existente.

### Testing

- Nenhum teste automatizado foi executado durante esta alteração (nenhum `npm`/`pnpm` test foi rodado).
- As mudanças foram verificadas localmente ao aplicar o patch e commitar o arquivo `src/routes/chatRoutes.js`.
- Nenhuma suíte de integração ou unitária foi disparada como parte deste rollout.
- Recomenda-se rodar a suíte de testes do projeto e validar `health/openai` e `health/rag` após a implantação.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fcd3b16088333889639bcd53354a6)