### PR TITLE
Refactor common route helpers: Mongo readiness, RAG checks, and API error formatting

### DIFF
--- a/src/routes/common.js
+++ b/src/routes/common.js
@@ -1,31 +1,79 @@
 import { connectToMongo, isConnected } from "../../db.js";
+import { getRAGInfo } from "../../rag-search.js";
 
-function shouldInitMongo() {
+/**
+ * Garante que o MongoDB está pronto
+ * @returns {Promise<boolean>}
+ */
+export async function ensureMongoReady() {
+  try {
+    if (isConnected()) {
+      return true;
+    }
+
+    if (process.env.MONGODB_URI) {
+      await connectToMongo();
+      return isConnected();
+    }
+
+    return false;
+  } catch (error) {
+    console.error("[COMMON] Erro ao conectar MongoDB:", error.message);
+    return false;
+  }
+}
+
+/**
+ * Verifica se o MongoDB deve ser inicializado
+ * @returns {boolean}
+ */
+export function shouldInitMongo() {
   return Boolean(process.env.MONGODB_URI);
 }
 
-function shouldInitRAG() {
-  return Boolean(process.env.OPENAI_API_KEY) && shouldInitMongo();
-}
+/**
+ * Verifica se o RAG deve ser inicializado
+ * @returns {boolean}
+ */
+export function shouldInitRAG() {
+  // RAG precisa de OpenAI API e MongoDB
+  const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
+  const hasMongo = Boolean(process.env.MONGODB_URI);
 
-async function ensureMongoReady() {
-  if (!shouldInitMongo()) {
+  if (!hasOpenAI) {
     return false;
   }
-  if (!isConnected()) {
-    try {
-      await connectToMongo();
-      console.log('✅ [COMMON] MongoDB conectado com sucesso');
-    } catch (err) {
-      console.warn("⚠️ [COMMON] MongoDB indisponível:", err.message);
-      return false;
-    }
+
+  if (!hasMongo) {
+    return false;
   }
-  return true;
+
+  // Verificar se RAG está inicializado
+  try {
+    const ragInfo = getRAGInfo();
+    return ragInfo.isInitialized && ragInfo.documentsCount > 0;
+  } catch (error) {
+    return false;
+  }
 }
 
-export {
+/**
+ * Formata erro para resposta da API
+ * @param {Error} error
+ * @returns {object}
+ */
+export function formatApiError(error) {
+  return {
+    success: false,
+    error: error.message || "Erro desconhecido",
+    code: error.code || "UNKNOWN_ERROR",
+    timestamp: new Date().toISOString()
+  };
+}
+
+export default {
   ensureMongoReady,
   shouldInitMongo,
-  shouldInitRAG
+  shouldInitRAG,
+  formatApiError
 };


### PR DESCRIPTION
### Motivation
- Garantir que a aplicação verifica corretamente se o MongoDB está conectado antes de servir rotas, com tratamento de erro robusto.
- Integrar a verificação do estado do RAG consultando `getRAGInfo` para só habilitar funcionalidades quando o RAG estiver inicializado e com documentos.
- Padronizar respostas de erro da API para facilitar logging e consumo com a nova função `formatApiError`.
- Manter compatibilidade com rotas administrativas expondo `shouldInitMongo` e fornecendo um `default` export consistente.

### Description
- Adiciona `getRAGInfo` import e implementa `ensureMongoReady` que usa `isConnected()` e `connectToMongo()` com `try/catch` e logs de erro.
- Implementa `shouldInitMongo` e `shouldInitRAG`, onde `shouldInitRAG` verifica `OPENAI_API_KEY`, `MONGODB_URI` e `getRAGInfo().isInitialized`/`documentsCount`.
- Adiciona `formatApiError(error)` que retorna um objeto padronizado com `success`, `error`, `code` e `timestamp`.
- Altera exportação para um `default` object contendo `ensureMongoReady`, `shouldInitMongo`, `shouldInitRAG` e `formatApiError` para uso consistente nas rotas.

### Testing
- Nenhum teste automatizado foi executado para estas alterações.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69601744b9a88333ae66bbeb4c740c24)