### PR TITLE
Support public `/resins` endpoint and update API client

### DIFF
--- a/apiClient.js
+++ b/apiClient.js
@@ -75,7 +75,7 @@ async function request(path, options = {}) {
 // =========================
 
 export async function fetchResins() {
-  return request("/api/resins");
+  return request("/resins");
 }
 
 export async function fetchPrinters(resinId) {

--- a/server.js
+++ b/server.js
@@ -61,7 +61,7 @@ app.get('/health', async (req, res) => {
 // ==========================================================
 // 1. ROTAS DE PARÂMETROS - Resinas e Impressoras
 // ==========================================================
-app.get('/api/resins', async (req, res) => {
+const handleResinsRequest = async (req, res) => {
   try {
     const collection = db.getParametrosCollection?.() || db.getCollection?.('parametros')
     if (!collection) {
@@ -75,7 +75,10 @@ app.get('/api/resins', async (req, res) => {
     console.error('[API] ❌ Erro ao buscar resinas:', error)
     res.status(500).json({ success: false, resins: [], message: 'Erro ao carregar resinas' })
   }
-})
+}
+
+app.get('/api/resins', handleResinsRequest)
+app.get('/resins', handleResinsRequest)
 
 app.get('/api/params/printers', async (req, res) => {
   try {


### PR DESCRIPTION
### Motivation
- Frontend now calls the public `/resins` path (no `/api` suffix), so the backend must expose a public route to avoid 404s/CORS issues.
- Resins data must be served directly from the MongoDB `parametros` collection (no local JSON fallbacks) to keep parameters up-to-date.
- Share the same handler for both internal (`/api/resins`) and public (`/resins`) endpoints to avoid duplication.

### Description
- Extracted the resins handler into `handleResinsRequest` and registered it on both `app.get('/api/resins', ...)` and `app.get('/resins', ...)` in `server.js`.
- The handler reads resins from the `parametros` collection via `db.getParametrosCollection` and returns `resins` as JSON.
- Updated the frontend API client `fetchResins()` in `apiClient.js` to call the public `/resins` path instead of `/api/resins`.
- Changes made in files: `server.js` and `apiClient.js`.

### Testing
- No automated tests were executed for this change.
- No test failures reported because automated test suite was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962644eaa908333861e04462150b369)