### PR TITLE
Serve /resins from MongoDB, update client calls, and enable corepack+pnpm on Render

### DIFF
--- a/apiClient.js
+++ b/apiClient.js
@@ -75,7 +75,7 @@ async function request(path, options = {}) {
 // =========================
 
 export async function fetchResins() {
-  return request("/api/resins");
+  return request("/resins");
 }
 
 export async function fetchPrinters(resinId) {

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     name: quanton3d-bot-v2
     env: node
     plan: free
-    buildCommand: npm install && npm run build
+    buildCommand: corepack enable && pnpm install --no-frozen-lockfile && pnpm run build
     startCommand: node server.js
     envVars:
       - key: NODE_VERSION
@@ -13,10 +13,15 @@ services:
         sync: false
       - key: OPENAI_API_KEY
         sync: false
+      - key: CI
+        value: "true"
 
   # Configuração do Site (Static Site)
   - type: web
     name: quanton3dia
     env: static
-    buildCommand: npm install && npm run build
+    buildCommand: corepack enable && pnpm install --no-frozen-lockfile && pnpm run build
     staticPublishPath: dist
+    envVars:
+      - key: CI
+        value: "true"

--- a/server.js
+++ b/server.js
@@ -61,7 +61,7 @@ app.get('/health', async (req, res) => {
 // ==========================================================
 // 1. ROTAS DE PARÂMETROS - Resinas e Impressoras
 // ==========================================================
-app.get('/api/resins', async (req, res) => {
+const handleResinsRequest = async (req, res) => {
   try {
     const collection = db.getParametrosCollection?.() || db.getCollection?.('parametros')
     if (!collection) {
@@ -75,7 +75,10 @@ app.get('/api/resins', async (req, res) => {
     console.error('[API] ❌ Erro ao buscar resinas:', error)
     res.status(500).json({ success: false, resins: [], message: 'Erro ao carregar resinas' })
   }
-})
+}
+
+app.get('/api/resins', handleResinsRequest)
+app.get('/resins', handleResinsRequest)
 
 app.get('/api/params/printers', async (req, res) => {
   try {


### PR DESCRIPTION
### Motivation
- Ensure the frontend reads live resin data from the database instead of stale JSON files by serving a public `/resins` endpoint that reads from the `parametros` collection.
- Keep behavior consistent and avoid duplicated handlers by sharing the same request handler for both internal and public resin routes.
- Prevent Render build failures caused by npm/pnpm environment mismatches by enabling Corepack and standardizing on `pnpm` in the deploy config.
- Make CI builds deterministic by setting `CI=true` during Render build steps.

### Description
- Extracted the resins logic into `handleResinsRequest` in `server.js` and registered it on both `app.get('/api/resins')` and `app.get('/resins')`, reading from `db.getParametrosCollection?.()` or `db.getCollection('parametros')` as available.
- Updated the frontend API client in `apiClient.js` so `fetchResins()` calls the public `"/resins"` path instead of `"/api/resins"`.
- Modified `render.yaml` to run `corepack enable && pnpm install --no-frozen-lockfile && pnpm run build` for both services and added `CI=true` to the service env vars to align build behavior.

### Testing
- No automated tests were executed for these changes.
- Manual sanity checks were performed by reviewing the modified routes and build commands in `server.js`, `apiClient.js`, and `render.yaml`.
- The updated `render.yaml` now contains the build command `corepack enable && pnpm install --no-frozen-lockfile && pnpm run build` for both services.
- No CI build was run as part of this change to validate the Render deployment behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962644eaa908333861e04462150b369)