### PR TITLE
Serve /resins from DB, add root form aliases, update client and Render build

### DIFF
--- a/apiClient.js
+++ b/apiClient.js
@@ -75,7 +75,7 @@ async function request(path, options = {}) {
 // =========================
 
 export async function fetchResins() {
-  return request("/api/resins");
+  return request("/resins");
 }
 
 export async function fetchPrinters(resinId) {

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     name: quanton3d-bot-v2
     env: node
     plan: free
-    buildCommand: npm install && npm run build
+    buildCommand: corepack enable && pnpm install --no-frozen-lockfile && pnpm run build
     startCommand: node server.js
     envVars:
       - key: NODE_VERSION
@@ -13,10 +13,15 @@ services:
         sync: false
       - key: OPENAI_API_KEY
         sync: false
+      - key: CI
+        value: "true"
 
   # Configuração do Site (Static Site)
   - type: web
     name: quanton3dia
     env: static
-    buildCommand: npm install && npm run build
+    buildCommand: corepack enable && pnpm install --no-frozen-lockfile && pnpm run build
     staticPublishPath: dist
+    envVars:
+      - key: CI
+        value: "true"

--- a/server.js
+++ b/server.js
@@ -61,7 +61,7 @@ app.get('/health', async (req, res) => {
 // ==========================================================
 // 1. ROTAS DE PARÂMETROS - Resinas e Impressoras
 // ==========================================================
-app.get('/api/resins', async (req, res) => {
+const handleResinsRequest = async (req, res) => {
   try {
     const collection = db.getParametrosCollection?.() || db.getCollection?.('parametros')
     if (!collection) {
@@ -75,7 +75,10 @@ app.get('/api/resins', async (req, res) => {
     console.error('[API] ❌ Erro ao buscar resinas:', error)
     res.status(500).json({ success: false, resins: [], message: 'Erro ao carregar resinas' })
   }
-})
+}
+
+app.get('/api/resins', handleResinsRequest)
+app.get('/resins', handleResinsRequest)
 
 app.get('/api/params/printers', async (req, res) => {
   try {
@@ -138,7 +141,7 @@ app.post('/api/gallery', async (req, res) => {
 // ==========================================================
 // 3. ROTAS DE FORMULÁRIOS (Correção dos 404)
 // ==========================================================
-app.post('/api/contact', async (req, res) => {
+const handleContactRequest = async (req, res) => {
   try {
     const collection = db.getCollection ? db.getCollection('messages') : null
     if (!collection) {
@@ -152,9 +155,12 @@ app.post('/api/contact', async (req, res) => {
     console.error('[FORM] ❌ Erro ao salvar contato:', error)
     res.status(500).json({ success: false, message: 'Erro ao enviar mensagem' })
   }
-})
+}
 
-app.post('/api/register-user', async (req, res) => {
+app.post('/api/contact', handleContactRequest)
+app.post('/contact', handleContactRequest)
+
+const handleRegisterUserRequest = async (req, res) => {
   try {
     const collection = db.getCollection ? db.getCollection('partners') : null
     if (!collection) {
@@ -169,9 +175,12 @@ app.post('/api/register-user', async (req, res) => {
     // Fallback: não travar o site
     res.status(200).json({ success: true, message: 'Cadastro recebido' })
   }
-})
+}
 
-app.post('/api/custom-request', async (req, res) => {
+app.post('/api/register-user', handleRegisterUserRequest)
+app.post('/register-user', handleRegisterUserRequest)
+
+const handleCustomRequest = async (req, res) => {
   try {
     const collection = db.getCollection ? db.getCollection('messages') : null
     if (!collection) {
@@ -185,9 +194,12 @@ app.post('/api/custom-request', async (req, res) => {
     console.error('[FORM] ❌ Erro ao salvar pedido:', error)
     res.status(500).json({ success: false, message: 'Erro ao enviar pedido' })
   }
-})
+}
 
-app.post('/api/suggest-knowledge', async (req, res) => {
+app.post('/api/custom-request', handleCustomRequest)
+app.post('/custom-request', handleCustomRequest)
+
+const handleSuggestKnowledgeRequest = async (req, res) => {
   try {
     const collection = db.getSuggestionsCollection?.() || db.getCollection?.('suggestions')
     if (!collection) {
@@ -201,7 +213,10 @@ app.post('/api/suggest-knowledge', async (req, res) => {
     console.error('[FORM] ❌ Erro ao salvar sugestão:', error)
     res.status(500).json({ success: false, message: 'Erro ao enviar sugestão' })
   }
-})
+}
+
+app.post('/api/suggest-knowledge', handleSuggestKnowledgeRequest)
+app.post('/suggest-knowledge', handleSuggestKnowledgeRequest)
 
 // ==========================================================
 // 4. ROTA DE ANÁLISE DE IMAGEM (NOVO!)


### PR DESCRIPTION
### Motivation
- Ensure frontend reads live resin data from the MongoDB `parametros` collection instead of stale JSON files by serving a public `/resins` endpoint. 
- Avoid 404s and CORS issues when the frontend posts forms to root paths by exposing non-`/api` aliases for form endpoints. 
- Standardize Render build environment to `pnpm` and make builds deterministic by enabling Corepack and setting `CI=true`.

### Description
- Added `handleResinsRequest` in `server.js` and registered it on both `GET /api/resins` and `GET /resins`, reading from `db.getParametrosCollection?.()` or `db.getCollection('parametros')` when available. 
- Replaced inline form handlers with shared handlers (`handleContactRequest`, `handleRegisterUserRequest`, `handleCustomRequest`, `handleSuggestKnowledgeRequest`) and registered each handler on both `/api/*` and root (`/*`) routes to provide non-API aliases. 
- Updated `apiClient.js` so `fetchResins()` calls the public `"/resins"` path instead of `"/api/resins"`. 
- Updated `render.yaml` to run `corepack enable && pnpm install --no-frozen-lockfile && pnpm run build` for both services and added `CI=true` environment variables.

### Testing
- No automated tests were executed for these changes. 
- Code changes were applied and committed successfully to the repository. 
- Repository inspection was performed using `rg` and `nl` to verify route and client updates. 
- Render deployment and CI builds were not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962644eaa908333861e04462150b369)