### PR TITLE
Mount chat routes at root to serve /chat and /ask endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -316,7 +316,7 @@ app.post('/auth/login', (req, res) => {
 // ==========================================================
 console.log('[ROUTES] 📡 Montando rotas do chat...')
 app.use('/api', chatRoutes)
-app.use('/chat', chatRoutes)
+app.use('/', chatRoutes)
 
 // ==========================================================
 // SERVIR FRONTEND (Arquivos Estáticos)


### PR DESCRIPTION
### Motivation
- Fix frontend 404s when chat endpoints are requested without the `/api` prefix.
- Ensure the backend serves chat routes from both the `/api` namespace and the application root to match frontend calls.
- Avoid routing mismatches that caused CORS/404 errors for `/ask`, `/chat`, and `/ask-with-image`.

### Description
- Replaced `app.use('/chat', chatRoutes)` with `app.use('/', chatRoutes)` so chat routes are mounted at the application root.
- Kept `app.use('/api', chatRoutes)` in place so `/api/*` endpoints continue to work as before.
- This change makes routes like `/ask`, `/chat`, and `/ask-with-image` reachable without the `/api` prefix.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962ff8f79248333b4cc752d46a8b1f9)