### PR TITLE
Expose /ask-with-image at root and mount chat routes at /

### DIFF
--- a/server.js
+++ b/server.js
@@ -272,6 +272,7 @@ const handleAskWithImage = async (req, res) => {
     res.json({
       success: true,
       reply,
+      response: reply,
       sessionId: sessionId || `img-${Date.now()}`
     })
 

--- a/src/routes/chatRoutes.js
+++ b/src/routes/chatRoutes.js
@@ -93,6 +93,7 @@ async function handleChatRequest(req, res) {
 
     res.json({
       reply: response.reply,
+      response: response.reply,
       sessionId: sessionId || 'session-auto',
       documentsUsed: response.documentsUsed
     });


### PR DESCRIPTION
### Motivation
- Ensure the image-analysis pipeline is reachable from the application root so frontend calls to `/ask-with-image` use the vision handler rather than the chat handler.
- Avoid routing mismatches that caused different behavior for image analysis when requests arrived without the `/api` prefix.
- Make chat endpoints reachable at the application root to match frontend calls and avoid 404/CORS errors.

### Description
- Added a shared handler `handleAskWithImage` in `server.js` and registered it for both `/api/ask-with-image` and `/ask-with-image` so the vision pipeline is used for root requests.
- Removed the non-vision `router.post('/ask-with-image', ...)` from `src/routes/chatRoutes.js` to prevent duplicated/mismatched handlers.
- Mounted chat routes at the application root by changing `app.use('/chat', chatRoutes)` to `app.use('/', chatRoutes)` so `/ask` and `/chat` are reachable without the `/api` prefix.
- Changes are contained in `server.js` and `src/routes/chatRoutes.js` and ensure the OpenAI vision call is invoked only via the new shared handler.

### Testing
- No automated tests were executed for this change.
- No test failures were reported because no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962ff8f79248333b4cc752d46a8b1f9)