### PR TITLE
Handle image payloads in chat, export DB helpers, and wire JWT admin auth

### DIFF
--- a/db.js
+++ b/db.js
@@ -6,7 +6,7 @@ const DEFAULT_OPTIONS = {
 
 let connectPromise = null
 
-export const connectToMongo = async (uri) => {
+export const connectToMongo = async (uri = process.env.MONGODB_URI) => {
   if (!uri) return false
 
   if (mongoose.connection.readyState === 1) {
@@ -27,10 +27,12 @@ export const connectToMongo = async (uri) => {
 }
 
 // Funções utilitárias para pegar coleções
-const getCollection = (name) => {
+export const getCollection = (name) => {
   if (!mongoose.connection?.db) return null
   return mongoose.connection.db.collection(name)
 }
+
+export const getDb = () => mongoose.connection?.db || null
 
 // Exportações que o RAG precisa
 export const getDocumentsCollection = () => getCollection('documents')
@@ -49,6 +51,8 @@ export const Conversas = mongoose.models.Conversas || mongoose.model('Conversas'
 
 export default {
   connectToMongo,
+  getCollection,
+  getDb,
   getDocumentsCollection,
   getVisualKnowledgeCollection,
   isConnected,

--- a/src/routes/chatRoutes.js
+++ b/src/routes/chatRoutes.js
@@ -5,6 +5,7 @@ import { searchKnowledge, formatContext } from '../../rag-search.js';
 const router = express.Router();
 
 const DEFAULT_CHAT_MODEL = process.env.OPENAI_CHAT_MODEL || 'gpt-4o-mini';
+const DEFAULT_IMAGE_MODEL = process.env.OPENAI_IMAGE_MODEL || 'gpt-4o';
 let openaiClient = null;
 
 function getOpenAIClient() {
@@ -26,17 +27,59 @@ function hasImagePayload(body = {}) {
   return Boolean(body.imageUrl || body.image || body.imageBase64 || body.imageData || body.attachment);
 }
 
-function summarizeImagePayload(body = {}) {
-  if (body.imageUrl) return `Imagem recebida via URL: ${body.imageUrl}`;
-  if (body.image) return 'Imagem recebida (campo image).';
-  if (body.imageBase64 || body.imageData || body.attachment) return 'Imagem recebida em formato base64/anexo.';
-  return '';
+function resolveImagePayload(body = {}) {
+  const possiblePayloads = [
+    body.imageUrl,
+    body.image,
+    body.imageBase64,
+    body.imageData,
+    body.attachment
+  ];
+
+  let payload = possiblePayloads.find(Boolean);
+  if (!payload) return null;
+
+  let mimeType =
+    body.imageMimeType ||
+    body.mimeType ||
+    'image/jpeg';
+
+  if (typeof payload === 'object') {
+    if (payload.url) {
+      return payload.url;
+    }
+    if (payload.data) {
+      mimeType = payload.mimeType || payload.type || mimeType;
+      payload = payload.data;
+    } else if (payload.base64) {
+      mimeType = payload.mimeType || payload.type || mimeType;
+      payload = payload.base64;
+    }
+  }
+
+  if (typeof payload !== 'string') {
+    return null;
+  }
+
+  const trimmed = payload.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('data:') || trimmed.startsWith('http')) {
+    return trimmed;
+  }
+
+  return `data:${mimeType};base64,${trimmed}`;
 }
 
-async function generateResponse({ message, imageSummary }) {
+async function getRagContext(message) {
   const trimmedMessage = typeof message === 'string' ? message.trim() : '';
   const ragResults = trimmedMessage ? await searchKnowledge(trimmedMessage) : [];
   const ragContext = formatContext(ragResults);
+
+  return { ragResults, ragContext, trimmedMessage };
+}
+
+async function generateResponse({ message, ragContext }) {
+  const trimmedMessage = typeof message === 'string' ? message.trim() : '';
 
   // --- AQUI ESTÁ A CORREÇÃO DA PERSONALIDADE ---
   const systemPrompt = `
@@ -51,10 +94,9 @@ async function generateResponse({ message, imageSummary }) {
   `;
 
   const prompt = [
-    `Contexto Técnico (Use isso para basear sua resposta):\n${ragContext}`,
+    ragContext ? `Contexto Técnico (Use isso para basear sua resposta):\n${ragContext}` : null,
     '---',
-    trimmedMessage ? `Cliente perguntou: ${trimmedMessage}` : 'Cliente enviou uma imagem.',
-    imageSummary ? `Detalhes da imagem: ${imageSummary}` : null,
+    trimmedMessage ? `Cliente perguntou: ${trimmedMessage}` : 'Cliente enviou uma imagem.'
   ].filter(Boolean).join('\n\n');
 
   const client = getOpenAIClient();
@@ -71,15 +113,59 @@ async function generateResponse({ message, imageSummary }) {
 
   return {
     reply: reply || 'Estou analisando sua solicitação, mas tive um breve soluço. Poderia repetir?',
-    documentsUsed: ragResults.length
+    documentsUsed: 0
+  };
+}
+
+async function generateImageResponse({ message, imageUrl, ragContext }) {
+  const trimmedMessage = typeof message === 'string' ? message.trim() : '';
+  const systemPrompt = `
+    Você é a IA Oficial da Quanton3D, especialista técnica em resinas e impressão 3D.
+    
+    SUAS REGRAS DE OURO:
+    1. JAMAIS cite fontes explicitamente como "(Fonte: Documento 1)" ou "[Doc 1]". Use o conhecimento naturalmente no texto.
+    2. Seja cordial, direto e profissional. Aja como um consultor técnico experiente.
+    3. Use formatação (negrito, tópicos) para deixar a leitura fácil.
+    4. Se o usuário relatar falhas (como "peça sem definição"), aja como suporte técnico: analise as causas prováveis (cura, limpeza, parâmetros) baseando-se no contexto.
+    5. Se a resposta não estiver no contexto, sugira contato humano pelo WhatsApp (31) 98334-0053.
+  `;
+
+  const prompt = [
+    ragContext ? `Contexto Técnico (Use isso para basear sua resposta):\n${ragContext}` : null,
+    '---',
+    trimmedMessage ? `Cliente perguntou: ${trimmedMessage}` : 'Cliente enviou uma imagem para análise.'
+  ].filter(Boolean).join('\n\n');
+
+  const client = getOpenAIClient();
+  const completion = await client.chat.completions.create({
+    model: DEFAULT_IMAGE_MODEL,
+    temperature: 0.4,
+    max_tokens: 1000,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: prompt },
+          { type: 'image_url', image_url: { url: imageUrl } }
+        ]
+      }
+    ]
+  });
+
+  const reply = completion?.choices?.[0]?.message?.content?.trim();
+
+  return {
+    reply: reply || 'Não consegui analisar a imagem agora. Pode tentar novamente?',
+    documentsUsed: 0
   };
 }
 
 async function handleChatRequest(req, res) {
   try {
     const { message, sessionId } = req.body ?? {};
-    const trimmedMessage = typeof message === 'string' ? message.trim() : '';
     const hasImage = hasImagePayload(req.body);
+    const { ragResults, ragContext, trimmedMessage } = await getRagContext(message);
 
     console.log(`[CHAT] Msg: ${trimmedMessage.substring(0, 50)}...`);
 
@@ -88,13 +174,25 @@ async function handleChatRequest(req, res) {
       return res.json({ reply: 'Olá! Sou a IA da Quanton3D. Como posso ajudar com suas impressões hoje?', sessionId: sessionId || 'new' });
     }
 
-    const imageSummary = hasImage ? summarizeImagePayload(req.body) : '';
-    const response = await generateResponse({ message: trimmedMessage, imageSummary });
+    let response = null;
+    if (hasImage) {
+      const imageUrl = resolveImagePayload(req.body);
+      if (!imageUrl) {
+        return res.status(400).json({ error: 'Imagem inválida ou não suportada.' });
+      }
+      response = await generateImageResponse({
+        message: trimmedMessage,
+        imageUrl,
+        ragContext
+      });
+    } else {
+      response = await generateResponse({ message: trimmedMessage, ragContext });
+    }
 
     res.json({
       reply: response.reply,
       sessionId: sessionId || 'session-auto',
-      documentsUsed: response.documentsUsed
+      documentsUsed: ragResults.length || response.documentsUsed
     });
   } catch (error) {
     console.error('Erro Chat:', error);


### PR DESCRIPTION
### Motivation
- Fix brittle image-analysis flow that failed on various payload formats and improve reliability of vision requests.
- Ensure shared DB helper access across routes and services to read the `parametros` collection directly from MongoDB.
- Replace a fragile inline admin auth handler with the JWT-based `authRoutes` module for safer admin access.
- Keep RAG context available when answering image and text requests so responses can reference technical knowledge.

### Description
- Added defaulting of `connectToMongo(uri = process.env.MONGODB_URI)` and exported `getCollection` and `getDb` from `db.js` for shared access to MongoDB helpers and collections.
- Reworked `src/routes/chatRoutes.js` to normalize/resolve multiple image payload formats via `resolveImagePayload`, added `DEFAULT_IMAGE_MODEL`, factored RAG lookup into `getRagContext`, and split text vs image responders into `generateResponse` and `generateImageResponse` that call the OpenAI chat completions appropriately.
- Wired admin authentication routes by mounting `authRoutes` at `'/auth'` and `'/api/auth'` in `server.js` and removed the legacy inline auth and the old standalone image handler to centralize behavior in `chatRoutes`.
- Adjusted response metadata so `documentsUsed` reflects RAG lookup counts when available and improved error handling for unsupported/invalid image payloads.

### Testing
- No automated tests were executed as part of this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696304ceccd88333bd8e323c0f54997c)