### PR TITLE
Fix API routing, Mongo collection helpers and improve chat image analysis

### DIFF
--- a/db.js
+++ b/db.js
@@ -6,7 +6,7 @@ const DEFAULT_OPTIONS = {
 
 let connectPromise = null
 
-export const connectToMongo = async (uri) => {
+export const connectToMongo = async (uri = process.env.MONGODB_URI) => {
   if (!uri) return false
 
   if (mongoose.connection.readyState === 1) {
@@ -27,10 +27,12 @@ export const connectToMongo = async (uri) => {
 }
 
 // Funções utilitárias para pegar coleções
-const getCollection = (name) => {
+export const getCollection = (name) => {
   if (!mongoose.connection?.db) return null
   return mongoose.connection.db.collection(name)
 }
+
+export const getDb = () => mongoose.connection?.db || null
 
 // Exportações que o RAG precisa
 export const getDocumentsCollection = () => getCollection('documents')
@@ -39,9 +41,12 @@ export const isConnected = () => mongoose.connection.readyState === 1
 
 // Exportações que o SITE precisa
 export const getGalleryCollection = () => getCollection('gallery')
-export const getSuggestionsCollection = () => getCollection('suggestions')
+export const getSuggestionsCollection = () => getCollection('sugestoes')
+export const getSugestoesCollection = () => getCollection('sugestoes')
 export const getMetricasCollection = () => getCollection('metricas')
 export const getParametrosCollection = () => getCollection('parametros')
+export const getPrintParametersCollection = () => getCollection('parametros')
+export const getConversasCollection = () => getCollection('conversas')
 
 const conversasSchema = new mongoose.Schema({}, { strict: false, collection: 'conversas' })
 
@@ -49,12 +54,17 @@ export const Conversas = mongoose.models.Conversas || mongoose.model('Conversas'
 
 export default {
   connectToMongo,
+  getCollection,
+  getDb,
   getDocumentsCollection,
   getVisualKnowledgeCollection,
   isConnected,
   getGalleryCollection,
   getSuggestionsCollection,
+  getSugestoesCollection,
   getMetricasCollection,
   getParametrosCollection,
+  getPrintParametersCollection,
+  getConversasCollection,
   Conversas,
 }

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -5,6 +5,7 @@ const router = express.Router();
 
 // Configurações
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'rmartins1201';
+const ADMIN_USER = process.env.ADMIN_USER || 'admin';
 const JWT_SECRET = process.env.ADMIN_JWT_SECRET || 'quanton3d_jwt_secret_key_2025';
 const JWT_EXPIRATION = '24h';
 const INVALID_TOKEN_RESPONSE = { success: false, error: 'Token inválido' };
@@ -15,7 +16,7 @@ const INVALID_TOKEN_RESPONSE = { success: false, error: 'Token inválido' };
  */
 router.post("/login", (req, res) => {
   try {
-    const { password } = req.body;
+    const { password, username } = req.body;
 
     // Validar senha
     if (!password) {
@@ -23,6 +24,14 @@ router.post("/login", (req, res) => {
       return res.status(400).json({
         success: false,
         error: "Senha é obrigatória"
+      });
+    }
+
+    if (username && username !== ADMIN_USER) {
+      console.log(`❌ [AUTH] Tentativa de login com usuario incorreto`);
+      return res.status(401).json({
+        success: false,
+        error: "Usuário incorreto"
       });
     }
 


### PR DESCRIPTION
### Motivation
- Fix mismatches between code and the production MongoDB schema so the system reads resins from the `parametros` collection and suggestions from `sugestoes` instead of falling back to files or wrong collection names.
- Restore compatibility with existing frontend/admin tools by exposing API and admin endpoints at both root and `/api` paths and reintroducing expected routes and metrics.
- Improve image-based troubleshooting by giving the chat endpoint proper image handling and making the AI responses more concise and conservative.
- Make database helpers and health checks more robust to avoid null/fallback behavior and to allow server code to access `getDb` and collection helpers uniformly.

### Description
- Exported `getCollection`, added `getDb`, `getPrintParametersCollection`, `getConversasCollection`, `getSugestoesCollection` and defaulted `connectToMongo` to use `process.env.MONGODB_URI` in `db.js` to centralize DB access.
- Refactored `src/routes/apiRoutes.js` to add a reusable `listParamResins()` helper, added a `/resins` alias, and switched to the new `getPrintParametersCollection` and `getSugestoesCollection` accessors.
- Wired up route modules in `server.js`, added a `/health/metrics` endpoint, mounted `apiRoutes`, `suggestionsRoutes`, `authRoutes` and admin routes at both root and `/api` as needed, and tightened the health DB check to use `isConnected`.
- Enhanced `src/routes/chatRoutes.js` to properly extract and normalize image payloads (`extractImageUrl`), send image-aware requests to the chat model, and enforce shorter, focused responses with lower `temperature` and a `max_tokens` limit; also adjusted auth to accept `username` in `src/routes/authRoutes.js`.

### Testing
- No automated tests were executed for these changes during the rollout.
- Existing project test commands remain available via the `test` npm script (`jest`) but were not run here.
- Basic type of changes were committed and smoke-checked locally (routing/exports), but no CI/test results to report.
- Recommend running the test suite (`pnpm test` or `npm test`) and exercising the `/resins`, `/params/*`, chat `/ask` and `/ask-with-image` endpoints in a staging environment after deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69634a09d5f08333800776c4248173f7)