### PR TITLE
Atualiza texto do painel de parâmetros para indicar 459 perfis e origem no banco

### DIFF
--- a/public/params-panel.html
+++ b/public/params-panel.html
@@ -347,7 +347,7 @@
       <header>
         <div>
           <h1>Painel de Parâmetros Quanton3D</h1>
-          <p>Filtros inteligentes para navegar pelos 458 perfis com clareza em qualquer tela.</p>
+          <p>Filtros inteligentes para navegar pelos 459 perfis com clareza, direto do banco (coleção parametros).</p>
         </div>
         <div class="stats" id="stats"></div>
       </header>


### PR DESCRIPTION
### Motivation
- Corrigir a informação exibida no painel para refletir o número atual de perfis (459).
- Deixar explícito que os perfis/resinas são carregados diretamente do banco de dados na coleção `parametros`.
- Evitar confusão que leve desenvolvedores a buscar dados em arquivos JSON ou coleções antigas.

### Description
- Atualiza o conteúdo do arquivo `public/params-panel.html` para mencionar `459` perfis e a origem no banco (`parametros`).
- A alteração é apenas de texto estático na interface e não altera rotas, API ou lógica do backend.

### Testing
- Levantei um servidor estático local com `python -m http.server 8000` para validar que o HTML carrega.
- Tentei gerar um screenshot via Playwright, mas o Chromium falhou ao iniciar e a captura não foi gerada.
- Não foram executados testes automatizados adicionais.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69634ba06a0c833398db1615f87b4056)