### PR TITLE
Fix image handling and select vision model for chat requests

### DIFF
--- a/src/routes/chatRoutes.js
+++ b/src/routes/chatRoutes.js
@@ -5,6 +5,7 @@ import { searchKnowledge, formatContext } from '../../rag-search.js';
 const router = express.Router();
 
 const DEFAULT_CHAT_MODEL = process.env.OPENAI_CHAT_MODEL || 'gpt-4o-mini';
+const DEFAULT_VISION_MODEL = process.env.OPENAI_VISION_MODEL || 'gpt-4o-mini';
 let openaiClient = null;
 
 function getOpenAIClient() {
@@ -26,20 +27,46 @@ function hasImagePayload(body = {}) {
   return Boolean(body.imageUrl || body.image || body.imageBase64 || body.imageData || body.attachment);
 }
 
+function normalizeImagePayload(body = {}) {
+  if (body.imageUrl) {
+    return { type: 'url', value: body.imageUrl };
+  }
+
+  const raw = body.image || body.imageBase64 || body.imageData || body.attachment;
+  if (!raw) return null;
+
+  if (typeof raw === 'string') {
+    if (raw.startsWith('data:')) {
+      return { type: 'data', value: raw };
+    }
+    return { type: 'data', value: `data:image/jpeg;base64,${raw}` };
+  }
+
+  if (typeof raw === 'object') {
+    const url = raw.url || raw.imageUrl;
+    if (typeof url === 'string' && url.length > 0) {
+      return { type: 'url', value: url };
+    }
+    const base64 = raw.base64 || raw.data || raw.imageBase64;
+    if (typeof base64 === 'string' && base64.length > 0) {
+      const mimeType = raw.mimeType || raw.type || raw.contentType || 'image/jpeg';
+      return { type: 'data', value: `data:${mimeType};base64,${base64}` };
+    }
+  }
+
+  return null;
+}
+
 function summarizeImagePayload(body = {}) {
-  if (body.imageUrl) return `Imagem recebida via URL: ${body.imageUrl}`;
-  if (body.image) return 'Imagem recebida (campo image).';
-  if (body.imageBase64 || body.imageData || body.attachment) return 'Imagem recebida em formato base64/anexo.';
-  return '';
+  const normalized = normalizeImagePayload(body);
+  if (!normalized) return '';
+  if (normalized.type === 'url') return `Imagem recebida via URL: ${normalized.value}`;
+  return 'Imagem recebida em formato base64/anexo.';
 }
 
 function extractImageUrl(body = {}) {
-  if (body.imageUrl) return body.imageUrl;
-  const raw = body.image || body.imageBase64 || body.imageData || body.attachment;
-  if (!raw) return null;
-  if (typeof raw === 'string' && raw.startsWith('data:')) return raw;
-  if (typeof raw === 'string') return `data:image/jpeg;base64,${raw}`;
-  return null;
+  const normalized = normalizeImagePayload(body);
+  return normalized ? normalized.value : null;
 }
 
 async function generateResponse({ message, imageSummary, imageUrl }) {
@@ -75,8 +102,10 @@ async function generateResponse({ message, imageSummary, imageUrl }) {
       ]
     : prompt;
 
+  const model = imageUrl ? DEFAULT_VISION_MODEL : DEFAULT_CHAT_MODEL;
+
   const completion = await client.chat.completions.create({
-    model: DEFAULT_CHAT_MODEL,
+    model,
     temperature: 0.3,
     max_tokens: 500,
     messages: [


### PR DESCRIPTION
### Motivation
- The chat endpoint sometimes failed to recognize or analyze user photos because it only handled a narrow set of image payload formats.  
- The server must accept image URLs, data URIs, raw base64 and structured image objects so image-based analysis works reliably.  
- Image requests must be routed to a vision-capable model rather than the default text model so OpenAI can analyze images.  
- Improve robustness of image extraction to prevent missed or malformed image payloads from being ignored.

### Description
- Added `DEFAULT_VISION_MODEL` (from `process.env.OPENAI_VISION_MODEL`) and select it when an image is present.  
- Implemented `normalizeImagePayload` to unify handling of URL, data URI, raw base64 and object payloads, and updated `summarizeImagePayload` and `extractImageUrl` to use the normalized result.  
- Dynamically choose the model with `model = imageUrl ? DEFAULT_VISION_MODEL : DEFAULT_CHAT_MODEL` and preserved existing RAG/context prompt construction.  
- Kept API routes and response shape unchanged so integrations remain compatible.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964568c2c8c8333bba274aaeb46935f)