### PR TITLE
Refine chat diagnostics to avoid unsupported guesses

### DIFF
--- a/src/routes/chatRoutes.js
+++ b/src/routes/chatRoutes.js
@@ -115,10 +115,11 @@ function attachMultipartImage(req, res, next) {
   next();
 }
 
-async function generateResponse({ message, imageSummary, imageUrl }) {
+async function generateResponse({ message, imageSummary, imageUrl, hasImage }) {
   const trimmedMessage = typeof message === 'string' ? message.trim() : '';
   const ragResults = trimmedMessage ? await searchKnowledge(trimmedMessage) : [];
   const ragContext = formatContext(ragResults);
+  const hasRelevantContext = ragResults.length > 0;
 
   // --- AQUI ESTÁ A CORREÇÃO DA PERSONALIDADE ---
   const systemPrompt = `
@@ -128,14 +129,17 @@ async function generateResponse({ message, imageSummary, imageUrl }) {
     1. JAMAIS cite fontes explicitamente como "(Fonte: Documento 1)" ou "[Doc 1]". Use o conhecimento naturalmente no texto.
     2. Seja cordial, direto e profissional. Aja como um consultor técnico experiente.
     3. Responda de forma objetiva (máximo de 6 a 8 linhas), com tópicos quando fizer sentido.
-    4. Se o usuário relatar falhas (como "peça sem definição"), aja como suporte técnico: analise as causas prováveis (cura, limpeza, parâmetros) baseando-se no contexto.
-    5. Se a resposta não estiver no contexto, diga que precisa de mais detalhes e sugira contato humano pelo WhatsApp (31) 98334-0053.
-    6. Não invente parâmetros nem diagnósticos; peça dados específicos quando necessário.
+    4. Só apresente causas prováveis quando houver CONTEXTO_RELEVANTE=SIM ou o cliente fornecer dados técnicos claros.
+    5. Se CONTEXTO_RELEVANTE=NAO, NÃO diagnostique. Peça informações objetivas (modelo da impressora, resina, tempo de exposição, altura de camada, velocidade de lift, temperatura, orientação/suportes) e ofereça ajuda humana no WhatsApp (31) 98334-0053.
+    6. Se IMAGEM=SIM, descreva rapidamente o que você observa sem afirmar a causa. Evite sugerir pós-cura, limpeza ou ajustes específicos sem dados ou contexto.
+    7. Nunca mencione uma resina específica (ex: Pyroblast+) se o cliente não citou ou se não estiver no contexto.
+    8. Não invente parâmetros nem diagnósticos; peça dados específicos quando necessário.
   `;
 
   const prompt = [
     `Contexto Técnico (Use isso para basear sua resposta):\n${ragContext}`,
     '---',
+    `Sinalizadores: CONTEXTO_RELEVANTE=${hasRelevantContext ? 'SIM' : 'NAO'} | IMAGEM=${hasImage ? 'SIM' : 'NAO'}`,
     trimmedMessage ? `Cliente perguntou: ${trimmedMessage}` : 'Cliente enviou uma imagem.',
     imageSummary ? `Detalhes da imagem: ${imageSummary}` : null,
   ].filter(Boolean).join('\n\n');
@@ -184,7 +188,12 @@ async function handleChatRequest(req, res) {
     }
 
     const imageSummary = hasImage ? summarizeImagePayload(req.body) : '';
-    const response = await generateResponse({ message: trimmedMessage, imageSummary, imageUrl });
+    const response = await generateResponse({
+      message: trimmedMessage,
+      imageSummary,
+      imageUrl,
+      hasImage
+    });
 
     res.json({
       reply: response.reply,


### PR DESCRIPTION
### Motivation
- The chat was producing unsupported diagnoses and mentioning specific resins without sufficient evidence, causing misleading answers.
- Image-only messages could lead to speculative troubleshooting when no contextual knowledge is available.
- We need to force the assistant to request objective printer/resin parameters before giving concrete diagnostic suggestions.

### Description
- Updated `generateResponse` in `src/routes/chatRoutes.js` to accept a `hasImage` flag and compute `hasRelevantContext` from RAG results.
- Hardened the `systemPrompt` to gate diagnostic suggestions and to forbid mentioning specific resins unless present in context. 
- Injected a `Sinalizadores` line into the user prompt with `CONTEXTO_RELEVANTE` and `IMAGEM` flags to guide model behavior. 
- Passed `hasImage` from `handleChatRequest` into `generateResponse` so image-only requests produce safer, non-diagnostic replies. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a10c1f288333b4d552ea4bf06cda)