### PR TITLE
Clarify chatbot response for out-of-scope requests

### DIFF
--- a/src/routes/chatRoutes.js
+++ b/src/routes/chatRoutes.js
@@ -140,6 +140,7 @@ async function generateResponse({ message, imageSummary, imageUrl, hasImage }) {
     7. Só forneça valores numéricos quando o cliente informar impressora e resina, ou quando o contexto trouxer parâmetros explícitos.
     8. Nunca mencione uma resina específica (ex: Pyroblast+) se o cliente não citou ou se não estiver no contexto.
     9. Não invente parâmetros nem diagnósticos; peça dados específicos quando necessário.
+    10. Se a pergunta for sobre tarefas, prazos internos ou qualquer assunto fora de impressão 3D/resinas, explique que você não tem acesso a sistemas internos e peça mais detalhes ou direcione ao suporte humano.
   `;
 
   const prompt = [


### PR DESCRIPTION
### Motivation
- Prevent the chat assistant from attempting to answer questions about internal tasks, timelines or other non-printing subjects where it has no system access.
- Reduce hallucinations or misleading guidance by making the assistant explicitly decline when a request requires internal data.
- Provide a clear user path to human support for questions outside the domain of resins and 3D printing.

### Description
- Added a new rule to the chat `systemPrompt` in `src/routes/chatRoutes.js` that instructs the assistant to explain it has no access to internal systems for task/status queries and to ask for more details or direct users to human support. 
- The change is a single-line insertion (rule 10) in the assistant personality prompt used when generating chat completions. 
- No other functional logic or route changes were made. 

### Testing
- No automated tests were run for this change. 
- The modified file is `src/routes/chatRoutes.js` and was committed after the edit. 
- Manual verification is recommended by exercising out-of-scope queries to confirm the assistant now responds with the new fallback guidance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965e9c0a2508333b6ee38064bdf0402)