### PR TITLE
Add API endpoints for custom requests and gallery uploads

### DIFF
--- a/src/routes/chatRoutes.js
+++ b/src/routes/chatRoutes.js
@@ -140,6 +140,7 @@ async function generateResponse({ message, imageSummary, imageUrl, hasImage }) {
     7. Só forneça valores numéricos quando o cliente informar impressora e resina, ou quando o contexto trouxer parâmetros explícitos.
     8. Nunca mencione uma resina específica (ex: Pyroblast+) se o cliente não citou ou se não estiver no contexto.
     9. Não invente parâmetros nem diagnósticos; peça dados específicos quando necessário.
+    10. Se a pergunta for sobre tarefas, prazos internos ou qualquer assunto fora de impressão 3D/resinas, explique que você não tem acesso a sistemas internos e peça mais detalhes ou direcione ao suporte humano.
   `;
 
   const prompt = [


### PR DESCRIPTION
### Motivation
- Disponibilizar um endpoint para receber pedidos de formulação customizada e outro para submissões de galeria de impressões.  
- Persistir essas submissões diretamente no MongoDB nas coleções `custom_requests` e `gallery` para evitar dependência de arquivos locais.  
- Garantir validação mínima de campos obrigatórios e verificar disponibilidade do banco com `ensureMongoReady`.  
- Facilitar triagem e acompanhamento através de registros com `status` e timestamps.  

### Description
- Adicionada a função helper `getCustomRequestsCollection` e implementados os endpoints `POST /custom-request` e `POST /gallery` em `src/routes/apiRoutes.js`.  
- Implementada validação de campos obrigatórios, normalização de imagens (`image`/`images`), criação de documentos com `status: "pending"` e campos `createdAt`/`updatedAt`.  
- Todas as rotas checam a conectividade do banco usando `ensureMongoReady` antes de inserir e registram ações relevantes via `console.log`.  
- As rotas retornam respostas JSON com `success` e o `id` inserido ou erros apropriados com códigos HTTP (400/503/500).  

### Testing
- Nenhum teste automatizado foi executado para estas alterações.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965e9c0a2508333b6ee38064bdf0402)