### PR TITLE
Restore direct Mongo writes for contact and gallery endpoints

### DIFF
--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -166,10 +166,7 @@ router.post("/contact", async (req, res) => {
       updatedAt: new Date()
     };
     
-    const result = await retryMongoWrite(
-      () => messagesCollection.insertOne(newMessage),
-      { label: "mensagem de contato" }
-    );
+    const result = await messagesCollection.insertOne(newMessage);
     console.log(`[API] Mensagem de contato recebida de: ${name} (${email})`);
     
     res.json({
@@ -299,10 +296,7 @@ router.post("/gallery", upload.any(), async (req, res) => {
       updatedAt: new Date()
     };
 
-    const result = await retryMongoWrite(
-      () => galleryCollection.insertOne(newEntry),
-      { label: "entrada de galeria" }
-    );
+    const result = await galleryCollection.insertOne(newEntry);
     console.log(`[API] Nova foto enviada para galeria: ${sanitizedResin} / ${printer}`);
 
     res.json({


### PR DESCRIPTION
### Motivation
- Fix a critical regression where the `retryMongoWrite` wrapper interfered with return values and caused DB writes/queries to fail, restoring reliable database inserts for contact and gallery submissions.

### Description
- In `src/routes/apiRoutes.js` replaced `await retryMongoWrite(() => messagesCollection.insertOne(...))` with `await messagesCollection.insertOne(...)` and similarly replaced the `retryMongoWrite` wrapper around `galleryCollection.insertOne(...)` to return the direct Mongo result and preserve `insertedId` in responses.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69687f87fb288333af77147599ee2324)