### PR TITLE
Remove retryMongoWrite wrapper from API routes

### DIFF
--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -8,8 +8,7 @@ import {
   getConversasCollection,
   getCollection,
   getDb,
-  isConnected,
-  retryMongoWrite
+  isConnected
 } from "../../db.js";
 import { ensureMongoReady } from "./common.js";
 
@@ -100,22 +99,19 @@ router.post("/register-user", async (req, res) => {
     
     if (sessionId) {
       const conversasCollection = getConversasCollection(); 
-      await retryMongoWrite(
-        () => conversasCollection.updateOne(
-          { sessionId },
-          {
-            $set: {
-              userName: name,
-              userPhone: phone,
-              userEmail: email,
-              resin: resin || null,
-              problemType: problemType || null,
-              updatedAt: new Date()
-            }
-          },
-          { upsert: true }
-        ),
-        { label: "conversa" }
+      await conversasCollection.updateOne(
+        { sessionId },
+        {
+          $set: {
+            userName: name,
+            userPhone: phone,
+            userEmail: email,
+            resin: resin || null,
+            problemType: problemType || null,
+            updatedAt: new Date()
+          }
+        },
+        { upsert: true }
       );
     }
     
@@ -222,10 +218,7 @@ router.post("/custom-request", async (req, res) => {
       updatedAt: new Date()
     };
 
-    const result = await retryMongoWrite(
-      () => customRequestsCollection.insertOne(newRequest),
-      { label: "pedido customizado" }
-    );
+    const result = await customRequestsCollection.insertOne(newRequest);
     console.log(`[API] Pedido de formulacao customizada: ${name} (${email})`);
 
     res.json({


### PR DESCRIPTION
### Motivation
- A prior "Stability/Retry" change caused silent database failures and locked out admin functionality, so the API must use direct Mongo calls again to restore Parameters, Gallery and Admin Login immediately.

### Description
- Updated `src/routes/apiRoutes.js` to remove the `retryMongoWrite` import and references and to use direct collection calls instead.
- Replaced the `retryMongoWrite`-wrapped `updateOne` for session/user updates with a direct `getConversasCollection().updateOne(...)` call.
- Replaced the `retryMongoWrite`-wrapped `insertOne` for custom requests with a direct `getCustomRequestsCollection().insertOne(...)` call.
- Preserved existing fuzzy-search logic and `parametros` collection usage (no changes to `getPrintParametersCollection()` or resin listing logic).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69688098647483339ff280b2c92a39ec)